### PR TITLE
feat(content-model): Sync the site structure model in code & on Contentful

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,7 +35,6 @@ if (!spaceId || !accessToken) {
 module.exports = {
   siteMetadata: {
     domain: 'distributeaid.org',
-    homePageSlug: 'home',
   },
   pathPrefix: '/',
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,21 +9,21 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
 
   /*
-  Gatsby Site Metadata
+  Site Metadata
   ------------------------------------------------------------
   */
-  const gatsbySiteResult = await graphql(`
+  const metadataResult = await graphql(`
     {
       site {
         siteMetadata {
           domain
-          homePageSlug
         }
+        pathPrefix
       }
     }
   `)
 
-  if (gatsbySiteResult.errors) {
+  if (metadataResult.errors) {
     reporter.panicOnBuild(`
       Error while running GraphQL query to get
       the siteMetadata set in gatsby-config.js.
@@ -31,25 +31,60 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     return
   }
 
-  const siteMetadata = gatsbySiteResult.data.site.siteMetadata
+  const domain = metadataResult.data.site.siteMetadata.domain
+  const pathPrefix = metadataResult.data.site.pathPrefix
 
   /*
-  Contentful Site Pages
+  Site Data
   ------------------------------------------------------------
   */
-  const contentfulSitePagesResult = await graphql(
+  const siteResult = await graphql(
     `
-      {
-        contentfulSite {
+      query Site {
+        contentfulSiteSite(domain: {eq: "${domain}"}) {
           contentful_id
+          title
+          domain
 
-          pages {
+          theme
+
+          homePage {
             contentful_id
+          }
+        }
+      }
+
+    `,
+  )
+
+  if (siteResult.errors) {
+    reporter.panicOnBuild(`
+      Error while running GraphQL query to get
+      the Site data from Contentful.
+    `)
+    return
+  }
+
+  const site = siteResult.data.contentfulSiteSite
+
+  /*
+  Pages Data
+  ------------------------------------------------------------
+  */
+  const pagesResult = await graphql(
+    `
+      query Pages {
+        allContentfulSitePage {
+          nodes {
+            contentful_id
+            title
             slug
 
-            tabs {
+            flavor
+            layout
+
+            leadsTo {
               contentful_id
-              slug
             }
           }
         }
@@ -57,50 +92,213 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     `,
   )
 
-  if (contentfulSitePagesResult.errors) {
+  if (pagesResult.errors) {
     reporter.panicOnBuild(`
       Error while running GraphQL query to get
-      the site pages from Contentful.
+      the Pages data from Contentful.
     `)
     return
   }
 
-  const contentfulSite = contentfulSitePagesResult.data.contentfulSite
+  const pages = pagesResult.data.allContentfulSitePage.nodes
+
+  /*
+  Process The Site's Structure
+  ------------------------------------------------------------
+  */
+
+  // create a page lookup by contentful_id
+  //
+  // ````
+  // pages.lookup = {contenful_id: page, ...}
+  // pages.lookup[contentful_id] = page | null
+  // ````
+  pages.lookup = pages.reduce((pageLookupAcc, page) => {
+    pageLookupAcc[page.contentful_id] = page
+    return pageLookupAcc
+  }, {})
+
+  // build a tree of pages by linking parent & child pages,
+  // and link em all to the site
+  //
+  // ```
+  // page.siteID = siteID
+  // parent.leadsTo  = [child, ...] | []
+  // child.comesFromID = parentID | homePageID | null
+  // ```
+  pages.forEach((page) => {
+    // link each page to the site
+    page.siteID = site.contentful_id
+
+    // setup empty child pointers for leaf pages
+    if (page.leadsTo === null) {
+      page.leadsTo = []
+    }
+
+    // set pointers from child -> parent pages to traverse up
+    const parent = page
+    parent.leadsTo = parent.leadsTo.map(({ contentful_id }) => {
+      child = pages.lookup[contentful_id]
+      child.comesFromID = parent.contentful_id
+      return child
+    })
+  })
+
+  // Setup the homepage as the root, the finishing touch on our page tree.
+  //
+  // ```
+  // site.homePage = homePage
+  //
+  // homePage.site = site
+  // homePage.comesFromID = null
+  // homePage.leadsTo = [topLevelPage, ...]
+  // homePage.slug = ''
+  //
+  // topLevelPage.comesFromID = homePageID
+  // ```
+  //
+  // NOTE: The homepage's slug is overridden, as it must be empty and it's the
+  //       only page that may have an empty slug.
+  //
+  // NOTE: The homepage must have `comesFromID` set to `null`, and is the only
+  //       page that should.
+  site.homePageID = site.homePage.contentful_id
+  homePage = pages.lookup[site.homePageID]
+  homePage.slug = ''
+  homePage.comesFromID = null
+  homePage.leadsTo = pages.filter(
+    (page) => page !== homePage && page.comesFromID == null,
+  )
+  homePage.leadsTo.forEach((page) => {
+    page.comesFromID = homePage.contentful_id
+  })
+
+  /*
+  Tree Traversal Helpers
+  ------------------------------------------------------------
+  TODO: move these into a utility file
+  */
+  const pageTreeUtils = {
+    getSiteRoot: () => {
+      return pages.lookup[site.homePageID]
+    },
+
+    BFS: (handlePage, root = null, filterChildren = null) => {
+      if (root === null) {
+        root = pageTreeUtils.getSiteRoot()
+      }
+
+      if (filterChildren === null) {
+        filterChildren = (page) => true
+      }
+
+      let queue = [root]
+      while (queue.length > 0) {
+        page = queue.shift()
+        handlePage(page)
+
+        next = page.leadsTo.filter(filterChildren)
+        queue = queue.concat(next)
+      }
+    },
+
+    preorderDFS: (handlePage, root = null, filterChildren = null) => {
+      if (root === null) {
+        root = pageTreeUtils.getSiteRoot()
+      }
+
+      if (filterChildren === null) {
+        filterChildren = (page) => page
+      }
+
+      handlePage(root)
+      root.leadsTo.filter(filterChildren).forEach((childPage) => {
+        pageTreeUtils.preorderDFS(handlePage, childPage, filterChildren)
+      })
+    },
+
+    postorderDFS: (handlePage, root = null, filterChildren = null) => {
+      if (root === null) {
+        root = pageTreeUtils.getSiteRoot()
+      }
+
+      if (filterChildren === null) {
+        filterChildren = (page) => page
+      }
+
+      root.leadsTo.filter(filterChildren).forEach((childPage) => {
+        pageTreeUtils.postorderDFS(handlePage, childPage, filterChildren)
+      })
+      handlePage(root)
+    },
+  }
+
+  /*
+  Set Tree-Based Page Properties
+  ------------------------------------------------------------
+    - path
+    - breadcrumbIDs
+  */
+  pageTreeUtils.preorderDFS((page) => {
+    // root page
+    if (page.contentful_id === site.homePageID) {
+      page.path = '/'
+      page.breadcrumbIDs = [page.contentful_id]
+    }
+
+    // parent page
+    else if (page.leadsTo.length > 0) {
+      parent = pages.lookup[page.comesFromID]
+      page.path = `${parent.path}${page.slug}/`
+      page.breadcrumbIDs = [...parent.breadcrumbIDs, page.contentful_id]
+    }
+
+    // leaf page
+    else {
+      parent = pages.lookup[page.comesFromID]
+      page.path = `${parent.path}${page.slug}`
+      page.breadcrumbIDs = [...parent.breadcrumbIDs, page.contentful_id]
+    }
+  })
 
   /*
   Create Pages
   ------------------------------------------------------------
   */
-  const mainPageTemplate = path.resolve(`./src/templates/MainPage.tsx`)
-  const tabPageTemplate = path.resolve(`./src/templates/TabPage.tsx`)
+  const pageLayouts = {
+    home: path.resolve(`./src/templates/MainPage.tsx`),
+    main: path.resolve(`./src/templates/MainPage.tsx`),
+    tabs: path.resolve(`./src/templates/TabPage.tsx`),
+  }
+  pageTreeUtils.BFS((page) => {
+    layout = pageLayouts.main
 
-  contentfulSite.pages.forEach((mainPage) => {
-    const mainPagePath =
-      mainPage.slug !== siteMetadata.homePageSlug ? `/${mainPage.slug}` : `/`
+    // unique homepage layout
+    if (page.contentful_id === site.homePageID) {
+      layout = pageLayouts.home
+    }
 
+    // tab pages (parent & children)
+    else if (
+      page.layout === 'Tabs' ||
+      pages.lookup[page.comesFromID].layout === 'Tabs'
+    ) {
+      layout = pageLayouts.tabs
+    }
+
+    // make the page
     createPage({
-      path: mainPagePath,
-      component: mainPageTemplate,
+      path: page.path,
+      component: layout,
       context: {
-        siteContentfulId: contentfulSite.contentful_id,
-        mainPageContentfulId: mainPage.contentful_id,
+        site: site,
+        pages: pages,
+        pageLookup: pages.lookup,
+        pageStructure: page,
+
+        // page query params
+        pageContentfulId: page.contentful_id,
       },
     })
-
-    if (mainPage.tabs !== null) {
-      mainPage.tabs.forEach((tabPage) => {
-        const tabPagePath = `${mainPagePath}/${tabPage.slug}`
-
-        createPage({
-          path: tabPagePath,
-          component: tabPageTemplate,
-          context: {
-            siteContentfulId: contentfulSite.contentful_id,
-            mainPageContentfulId: mainPage.contentful_id,
-            tabPageContentfulId: tabPage.contentful_id,
-          },
-        })
-      })
-    }
   })
 }

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import ContentMarkdown from './ContentMarkdown'
+import ContentPhoto from './ContentPhoto'
+import ContentPrezi from './ContentPrezi'
+
+const Content = ({ section, content }) => {
+  switch (content.internal.type) {
+    case 'ContentfulContentMarkdown':
+      return <ContentMarkdown content={content} />
+
+    case 'ContentfulContentPhoto':
+      return <ContentPhoto content={content} />
+
+    case 'ContentfulContentPrezi':
+      return <ContentPrezi content={content} />
+
+    default:
+      return null
+  }
+}
+
+export default Content

--- a/src/components/Content/ContentMarkdown.tsx
+++ b/src/components/Content/ContentMarkdown.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const ContentMarkdown = ({ content }) => {
+  const markdownHtml = content.entry.childMarkdownRemark.html
+
+  return <div dangerouslySetInnerHTML={{ __html: markdownHtml }} />
+}
+
+export default ContentMarkdown

--- a/src/components/Content/ContentPhoto.tsx
+++ b/src/components/Content/ContentPhoto.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const ContentPhoto = ({ content }) => {
+  const { file, title, description } = content.entry
+
+  return (
+    <div>
+      <img src={file.url} alt={description} />
+      <h3>{title}</h3>
+    </div>
+  )
+}
+
+export default ContentPhoto

--- a/src/components/Content/ContentPrezi.tsx
+++ b/src/components/Content/ContentPrezi.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const ContentPrezi = ({ content }) => {
+  const { width, height, embedUrl } = content
+
+  return (
+    <iframe
+      width={width}
+      height={height}
+      src={embedUrl}
+      webkitAllowFullscreen="1"
+      mozAllowFullscreen="1"
+      allowFullScreen="1"
+    ></iframe>
+  )
+}
+
+export default ContentPrezi

--- a/src/components/Content/index.ts
+++ b/src/components/Content/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Content'

--- a/src/components/NavBreadcrumbs/NavBreadcrumbs.tsx
+++ b/src/components/NavBreadcrumbs/NavBreadcrumbs.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'gatsby'
+import React from 'react'
+
+const NavBreadcrumbs = ({ pageLookup, page }) => {
+  return (
+    <nav aria-label="breadcrumb" role="navigation">
+      <strong>Breadcrumbs:</strong>
+      <ol className="flex leading-none text-indigo-600 divide-x divide-indigo-400">
+        {page.breadcrumbIDs.map((breadcrumbID) => {
+          const breadcrumb = pageLookup[breadcrumbID]
+          return (
+            <li key={breadcrumb.contentful_id} className="px-4">
+              <Link to={`${breadcrumb.path}`}>{breadcrumb.title}</Link>
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}
+
+export default NavBreadcrumbs

--- a/src/components/NavBreadcrumbs/index.ts
+++ b/src/components/NavBreadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NavBreadcrumbs'

--- a/src/components/NavMain/NavMain.tsx
+++ b/src/components/NavMain/NavMain.tsx
@@ -1,30 +1,47 @@
 import { graphql, Link, useStaticQuery } from 'gatsby'
 import React from 'react'
 
-const NavMain = () => {
+const NavMain = (props) => {
   const data = useStaticQuery(graphql`
-    query NavMainComponentQuery {
-      contentfulSite {
+    query MainMenuQuery {
+      contentfulSiteSite {
         contentful_id
 
-        pages {
+        mainMenu {
           contentful_id
           title
-          slug
+          flavor
+          layout
+
+          links {
+            contentful_id
+            label
+            type
+
+            toPage {
+              contentful_id
+            }
+          }
         }
       }
     }
   `)
 
-  const pages = data.contentfulSite.pages
+  const { pageLookup, page } = props
+
+  const menu = data.contentfulSiteSite.mainMenu
+  menu.links.forEach((link) => {
+    link.toPage = pageLookup[link.toPage.contentful_id]
+  })
 
   return (
     <nav role="navigation">
       <ul className="flex justify-center h-48">
-        {pages.map((page) => {
+        {menu.links.map((link) => {
+          const label = link.label ? link.label : link.toPage.title
           return (
-            <li key={page.contentful_id} className="mx-4">
-              <Link to={`/${page.slug}`}>{page.title}</Link>
+            <li key={link.toPage.contentful_id} className="mx-4">
+              <Link to={`${link.toPage.path}`}>{label}</Link>
             </li>
           )
         })}

--- a/src/components/NavTabs/NavTabs.tsx
+++ b/src/components/NavTabs/NavTabs.tsx
@@ -1,25 +1,30 @@
 import { Link } from 'gatsby'
 import React from 'react'
 
-const NavTabs = ({ page, tabs }) => {
-  if (tabs === null) {
-    tabs = []
-  }
+const NavTabs = ({ pageLookup, page }) => {
+  const indexPage = page.layout === 'Tabs' ? page : pageLookup[page.comesFromID]
 
   return (
-    <nav role="navigation">
-      <ul>
-        <li key={page.contentful_id}>
-          <Link to={`/${page.slug}`}>{page.title}</Link>
+    <nav role="navigation" className="flex flex-col sm:flex-row">
+      <strong>Tabs</strong>
+      <ol className="flex leading-none">
+        <li
+          key={indexPage.contentful_id}
+          className="text-gray-600 py-4 px-6 block hover:text-blue-500 focus:outline-none text-blue-500 border-b-2 font-medium border-blue-500"
+        >
+          <Link to={indexPage.path}>{indexPage.title}</Link>
         </li>
-        {tabs.map((tab) => {
+        {indexPage.leadsTo.map((tabPage) => {
           return (
-            <li key={tab.contentful_id}>
-              <Link to={`/${page.slug}/${tab.slug}`}>{tab.title}</Link>
+            <li
+              key={tabPage.contentful_id}
+              className="text-gray-600 py-4 px-6 block hover:text-blue-500 focus:outline-none"
+            >
+              <Link to={tabPage.path}>{tabPage.title}</Link>
             </li>
           )
         })}
-      </ul>
+      </ol>
     </nav>
   )
 }

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import Content from '../Content'
+import SectionStack from './SectionStack'
+
+// import Row from '../components/SectionRow'
+// import Grid from '../components/SectionGrid'
+
+// import TableOfContents from '../components/SectionTableOfContents'
+// import Gallery from '../components/SectionGallery'
+
+const Section = ({ page, section }) => {
+  if (section.content === null) {
+    section.content = []
+  }
+
+  switch (section.layout) {
+    case 'Stack':
+      return (
+        <SectionStack page={page} section={section}>
+          {section.content.map((content) => {
+            return (
+              <div key={content.contentful_id}>
+                <Content section={section} content={content} />
+              </div>
+            )
+          })}
+        </SectionStack>
+      )
+
+    default:
+      return (
+        <SectionStack page={page} section={section}>
+          {section.content.map((content) => {
+            return (
+              <Content
+                key={content.contentful_id}
+                section={section}
+                content={content}
+              />
+            )
+          })}
+        </SectionStack>
+      )
+  }
+}
+
+export default Section

--- a/src/components/Section/SectionStack.tsx
+++ b/src/components/Section/SectionStack.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+class SectionStack extends React.Component {
+  render() {
+    const { section, children } = this.props
+
+    return (
+      <section id={section.slug} className={section.flavor}>
+        <h2>{section.title}</h2>
+        {children}
+      </section>
+    )
+  }
+}
+
+export default SectionStack

--- a/src/components/Section/index.ts
+++ b/src/components/Section/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Section'

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -1,14 +1,19 @@
 import React from 'react'
+import NavBreadcrumbs from '../components/NavBreadcrumbs'
 import NavMain from '../components/NavMain'
 
 class DefaultLayout extends React.Component {
   render() {
-    const { children } = this.props
+    const { site, pages, pageLookup, page, children } = this.props
 
     return (
       <div>
-        <NavMain />
-        {children}
+        <header>
+          <NavMain pageLookup={pageLookup} page={page} />
+          <NavBreadcrumbs pageLookup={pageLookup} page={page} />
+        </header>
+        <main>{children}</main>
+        <footer>Footer</footer>
       </div>
     )
   }

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Helmet } from 'react-helmet'
 import NavBreadcrumbs from '../components/NavBreadcrumbs'
 import NavMain from '../components/NavMain'
 
@@ -7,14 +8,18 @@ class DefaultLayout extends React.Component {
     const { site, pages, pageLookup, page, children } = this.props
 
     return (
-      <div>
+      <>
+        {/* html document head */}
+        <Helmet title={`${page.title} < ${site.title}`} />
+
+        {/* site level header / body / footer */}
         <header>
           <NavMain pageLookup={pageLookup} page={page} />
           <NavBreadcrumbs pageLookup={pageLookup} page={page} />
         </header>
         <main>{children}</main>
         <footer>Footer</footer>
-      </div>
+      </>
     )
   }
 }

--- a/src/templates/MainPage.tsx
+++ b/src/templates/MainPage.tsx
@@ -1,6 +1,5 @@
 import { graphql } from 'gatsby'
 import React from 'react'
-import { Helmet } from 'react-helmet'
 import Section from '../components/Section'
 import DefaultLayout from '../layouts/Default'
 
@@ -23,13 +22,12 @@ class MainPageTemplate extends React.Component {
         pageLookup={pageLookup}
         page={page}
       >
-        <Helmet title={`${page.title} < ${site.title}`} />
-
+        {/* page header */}
         <header>
           <h1>{page.title}</h1>
-          <p>{page.updatedAt}</p>
         </header>
 
+        {/* page body */}
         {page.sections.map((section) => {
           return (
             <Section
@@ -39,6 +37,11 @@ class MainPageTemplate extends React.Component {
             />
           )
         })}
+
+        {/* page footer */}
+        <footer>
+          <p>{page.updatedAt}</p>
+        </footer>
       </DefaultLayout>
     )
   }

--- a/src/templates/MainPage.tsx
+++ b/src/templates/MainPage.tsx
@@ -1,30 +1,44 @@
 import { graphql } from 'gatsby'
-import get from 'lodash/get'
 import React from 'react'
 import { Helmet } from 'react-helmet'
-import NavTabs from '../components/NavTabs'
+import Section from '../components/Section'
 import DefaultLayout from '../layouts/Default'
 
 class MainPageTemplate extends React.Component {
   render() {
-    const site = get(this.props, 'data.contentfulPageMain.site')
-    const page = get(this.props, 'data.contentfulPageMain')
-    const tabs = get(this.props, 'data.contentfulPageMain.tabs')
+    const { site, pages, pageLookup, pageStructure } = this.props.pageContext
+    const pageDetails = this.props.data.contentfulSitePage
+    const page = {
+      ...pageStructure,
+      ...pageDetails,
+    }
+    if (page.sections === null) {
+      page.sections = []
+    }
 
     return (
-      <DefaultLayout>
-        <div>
-          <Helmet title={`${page.title} // ${site.title}`} />
+      <DefaultLayout
+        site={site}
+        pages={pages}
+        pageLookup={pageLookup}
+        page={page}
+      >
+        <Helmet title={`${page.title} < ${site.title}`} />
+
+        <header>
           <h1>{page.title}</h1>
+          <p>{page.updatedAt}</p>
+        </header>
 
-          <NavTabs page={page} tabs={tabs} />
-
-          <div>
-            <p>{page.updatedAt}</p>
-
-            <p>TODO: show page content</p>
-          </div>
-        </div>
+        {page.sections.map((section) => {
+          return (
+            <Section
+              key={section.contentful_id}
+              page={page}
+              section={section}
+            />
+          )
+        })}
       </DefaultLayout>
     )
   }
@@ -33,22 +47,71 @@ class MainPageTemplate extends React.Component {
 export default MainPageTemplate
 
 export const pageQuery = graphql`
-  query MainPageQuery($mainPageContentfulId: String!) {
-    contentfulPageMain(contentful_id: { eq: $mainPageContentfulId }) {
+  query MainPageDetails($pageContentfulId: String!) {
+    contentfulSitePage(contentful_id: { eq: $pageContentfulId }) {
       contentful_id
       title
-      slug
-      updatedAt(formatString: "MMMM Do, YYYY")
+      flavor
+      updatedAt
 
-      site {
-        contentful_id
-        title
-      }
-
-      tabs {
+      sections {
         contentful_id
         title
         slug
+
+        flavor
+        layout
+
+        content {
+          ... on ContentfulContentMarkdown {
+            contentful_id
+            label
+            internal {
+              type
+            }
+            entry {
+              childMarkdownRemark {
+                html
+              }
+            }
+          }
+
+          ... on ContentfulContentPhoto {
+            contentful_id
+            label
+            internal {
+              type
+            }
+            entry {
+              contentful_id
+              title
+              description
+              file {
+                contentType
+                url
+                details {
+                  image {
+                    width
+                    height
+                  }
+                  size
+                }
+              }
+            }
+          }
+
+          ... on ContentfulContentPrezi {
+            contentful_id
+            label
+            internal {
+              type
+            }
+
+            width
+            height
+            embedUrl
+          }
+        }
       }
     }
   }

--- a/src/templates/TabPage.tsx
+++ b/src/templates/TabPage.tsx
@@ -1,58 +1,47 @@
 import { graphql } from 'gatsby'
-import get from 'lodash/get'
 import React from 'react'
 import { Helmet } from 'react-helmet'
 import NavTabs from '../components/NavTabs'
-import Layout from '../layouts/Default'
+import Section from '../components/Section'
+import DefaultLayout from '../layouts/Default'
 
 class TabPageTemplate extends React.Component {
   render() {
-    const site = get(
-      this.props,
-      'data.contentfulPageTab.page___main[0].site[0]',
-    )
-    const page = get(this.props, 'data.contentfulPageTab.page___main[0]')
-    const tabs = get(this.props, 'data.contentfulPageTab.page___main[0].tabs')
-    const tab = get(this.props, 'data.contentfulPageTab')
+    const { site, pages, pageLookup, pageStructure } = this.props.pageContext
+    const pageDetails = this.props.data.contentfulSitePage
+    const page = {
+      ...pageStructure,
+      ...pageDetails,
+    }
+    if (page.sections === null) {
+      page.sections = []
+    }
 
     return (
-      <Layout>
-        <div>
-          <Helmet title={`${tab.title} // ${site.title}`} />
-          <h1>{tab.title}</h1>
+      <DefaultLayout
+        site={site}
+        pages={pages}
+        pageLookup={pageLookup}
+        page={page}
+      >
+        <Helmet title={`${page.title} < ${site.title}`} />
 
-          <NavTabs page={page} tabs={tabs} />
+        <header>
+          <NavTabs pageLookup={pageLookup} page={page} />
+          <h1>{page.title}</h1>
+          <p>{page.updatedAt}</p>
+        </header>
 
-          <div>
-            <p>{tab.updatedAt}</p>
-
-            {tab.sections.map((section) => {
-              return (
-                <div>
-                  <h2>{section.title}</h2>
-
-                  {section.content.map((content) => {
-                    if (content.contentful_id == null) {
-                      return null
-                    }
-
-                    return (
-                      <div
-                        dangerouslySetInnerHTML={{
-                          __html:
-                            content
-                              .childContentfulComponentMarkdownContentTextNode
-                              .childMarkdownRemark.html,
-                        }}
-                      />
-                    )
-                  })}
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      </Layout>
+        {page.sections.map((section) => {
+          return (
+            <Section
+              key={section.contentful_id}
+              page={page}
+              section={section}
+            />
+          )
+        })}
+      </DefaultLayout>
     )
   }
 }
@@ -60,46 +49,69 @@ class TabPageTemplate extends React.Component {
 export default TabPageTemplate
 
 export const pageQuery = graphql`
-  query TabPageQuery($tabPageContentfulId: String!) {
-    contentfulPageTab(contentful_id: { eq: $tabPageContentfulId }) {
+  query TabPageDetails($pageContentfulId: String!) {
+    contentfulSitePage(contentful_id: { eq: $pageContentfulId }) {
       contentful_id
       title
-      slug
-      updatedAt(formatString: "MMMM Do, YYYY")
+      flavor
+      updatedAt
 
-      page___main {
+      sections {
         contentful_id
         title
         slug
 
-        site {
-          contentful_id
-          title
-        }
+        flavor
+        layout
 
-        tabs {
-          contentful_id
-          title
-          slug
-        }
-      }
+        content {
+          ... on ContentfulContentMarkdown {
+            contentful_id
+            label
+            internal {
+              type
+            }
+            entry {
+              childMarkdownRemark {
+                html
+              }
+            }
+          }
 
-      sections {
-        ... on ContentfulSectionContent {
-          contentful_id
-          title
-
-          content {
-            ... on ContentfulComponentMarkdown {
+          ... on ContentfulContentPhoto {
+            contentful_id
+            label
+            internal {
+              type
+            }
+            entry {
               contentful_id
-              name
-
-              childContentfulComponentMarkdownContentTextNode {
-                childMarkdownRemark {
-                  html
+              title
+              description
+              file {
+                contentType
+                url
+                details {
+                  image {
+                    width
+                    height
+                  }
+                  size
                 }
               }
             }
+          }
+
+          ... on ContentfulContentPrezi {
+            contentful_id
+            label
+            internal {
+              type
+            }
+
+            width
+            height
+            embedUrl
           }
         }
       }

--- a/src/templates/TabPage.tsx
+++ b/src/templates/TabPage.tsx
@@ -1,6 +1,5 @@
 import { graphql } from 'gatsby'
 import React from 'react'
-import { Helmet } from 'react-helmet'
 import NavTabs from '../components/NavTabs'
 import Section from '../components/Section'
 import DefaultLayout from '../layouts/Default'
@@ -24,14 +23,14 @@ class TabPageTemplate extends React.Component {
         pageLookup={pageLookup}
         page={page}
       >
-        <Helmet title={`${page.title} < ${site.title}`} />
-
+        {/* page header */}
         <header>
           <NavTabs pageLookup={pageLookup} page={page} />
           <h1>{page.title}</h1>
           <p>{page.updatedAt}</p>
         </header>
 
+        {/* page body */}
         {page.sections.map((section) => {
           return (
             <Section
@@ -41,6 +40,11 @@ class TabPageTemplate extends React.Component {
             />
           )
         })}
+
+        {/* page footer */}
+        <footer>
+          <p>{page.updatedAt}</p>
+        </footer>
       </DefaultLayout>
     )
   }

--- a/src/utils/PageTreeTraversal.js
+++ b/src/utils/PageTreeTraversal.js
@@ -1,0 +1,44 @@
+/*
+Page Tree Traversal Helpers
+------------------------------------------------------------
+NOTE: In JS so it can be used by `/gatsby-node.js` too.
+*/
+
+function BFS(root, handlePage, filterChildren = null) {
+  if (filterChildren === null) {
+    filterChildren = (page) => true
+  }
+
+  let queue = [root]
+  while (queue.length > 0) {
+    page = queue.shift()
+    handlePage(page)
+
+    next = page.leadsTo.filter(filterChildren)
+    queue = queue.concat(next)
+  }
+}
+
+function preorderDFS(root, handlePage, filterChildren = null) {
+  if (filterChildren === null) {
+    filterChildren = (page) => page
+  }
+
+  handlePage(root)
+  root.leadsTo.filter(filterChildren).forEach((childPage) => {
+    preorderDFS(childPage, handlePage, filterChildren)
+  })
+}
+
+function postorderDFS(root, handlePage, filterChildren = null) {
+  if (filterChildren === null) {
+    filterChildren = (page) => page
+  }
+
+  root.leadsTo.filter(filterChildren).forEach((childPage) => {
+    PageTreeTraversal.postorderDFS(childPage, handlePage, filterChildren)
+  })
+  handlePage(root)
+}
+
+module.exports = { BFS, preorderDFS, postorderDFS }


### PR DESCRIPTION
Includes the following working bits:

  - page generation w/ sections & content
  - 2 page layouts
  - 1 content section layout
  - various nav options
  - and 3 different types of content!

Pages are represented as an unbalanced parent > child tree which is useful in various ways when navigating the whole site structure or sub-structures withing the site.

**Reviewers:** Pretty large and potentially messy- tag issues that you see for sure!  But it's ok to pull a larger thing out into an issue to tackle later as well. :)