### PR TITLE
Refactor: Move PageBanner Component From Content to Section 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ By contributing to this project you agree to:
 - Sanket Dive
 - Ramón Huidobro
 - K. Hendrikse
+- Aaron Pedwell

--- a/src/components/section/Section.tsx
+++ b/src/components/section/Section.tsx
@@ -9,7 +9,7 @@ import {
 // import Gallery from './SectionGallery'
 import ImageCarousel from '../carousel/ImageCarousel'
 import Content from '../content/Content'
-import PageBanner from '../content/PageBanner'
+import SectionPageBanner from './SectionPageBanner'
 import SectionStack from './SectionStack'
 
 interface Props {
@@ -39,8 +39,8 @@ const Section: FunctionComponent<Props> = ({ page, section }) => {
     case 'HeaderCarousel':
       return <ImageCarousel section={section} />
 
-    case 'PageBanner':
-      return <PageBanner section={section} />
+    case 'SectionPageBanner':
+      return <SectionPageBanner section={section} />
 
     case 'ShipmentBanner':
       return null

--- a/src/components/section/Section.tsx
+++ b/src/components/section/Section.tsx
@@ -39,7 +39,7 @@ const Section: FunctionComponent<Props> = ({ page, section }) => {
     case 'HeaderCarousel':
       return <ImageCarousel section={section} />
 
-    case 'SectionPageBanner':
+    case 'PageBanner':
       return <SectionPageBanner section={section} />
 
     case 'ShipmentBanner':

--- a/src/components/section/SectionPageBanner.tsx
+++ b/src/components/section/SectionPageBanner.tsx
@@ -7,7 +7,7 @@ interface Props {
   section: ContentfulSitePageSection
 }
 
-const PageBanner: FunctionComponent<Props> = ({ section }) => {
+const SectionPageBanner: FunctionComponent<Props> = ({ section }) => {
   return (
     <div className="flex flex-col md:flex-row justify-center items-center gap-8 bg-gray-100 px-16 py-20 font-sans text-2xl text-navy-600">
       {section.content &&
@@ -34,4 +34,4 @@ const PageBanner: FunctionComponent<Props> = ({ section }) => {
   )
 }
 
-export default PageBanner
+export default SectionPageBanner


### PR DESCRIPTION
Closes #37
This commit refactors the code by moving the component to the right part of the codebase.

Moved src/components/content/PageBanner.tsx to src/components/section/. 
Made sure the imports to/from the file aren't broken!
Renamed the component to SectionPageBanner.tsx. 
Made sure to update the components name within the file!