### PR TITLE
Harcode the navigation and fix the logo size

### DIFF
--- a/src/components/brand/BrandMark.tsx
+++ b/src/components/brand/BrandMark.tsx
@@ -12,13 +12,11 @@ interface LogosData {
 interface Props {
   flavor?: Flavors
   layout?: BrandMarkLayouts
-  className?: string
 }
 
 const BrandMark: FunctionComponent<Props> = ({
   flavor = 'white',
   layout = 'logo',
-  className = '',
 }) => {
   const data: LogosData = useStaticQuery(graphql`
     query BrandMarkQuery {
@@ -60,9 +58,7 @@ const BrandMark: FunctionComponent<Props> = ({
   }
 
   return (
-    <div className={className}>
-      <img src={logo.file.url} alt={`${logo.title}`} />
-    </div>
+    <img src={logo.file.url} alt={`${logo.title}`} width="50" height="42.5" />
   )
 }
 

--- a/src/components/nav/MainMenu/MainMenu.tsx
+++ b/src/components/nav/MainMenu/MainMenu.tsx
@@ -1,6 +1,4 @@
-import { ContentfulSiteSite } from '@types/gatsby-graphql-types.gen'
-import { PageContext } from '@types/site-types'
-import { graphql, Link, useStaticQuery } from 'gatsby'
+import { Link } from 'gatsby'
 import { FunctionComponent } from 'react'
 import BrandMark from '../../brand/BrandMark'
 import DesktopNavigation from './MainMenuDesktop'
@@ -11,73 +9,40 @@ export interface NavLinkItem {
   path: string
 }
 
-interface Props {
-  pageContext: PageContext
-}
-
-interface MainMenuData {
-  contentfulSiteSite: ContentfulSiteSite
-}
-
 /**
  * A full-width element that sits at the top of the page. It displays the DA
  * branding and a dropdown-menu with some account information.
  */
-const MainMenu: FunctionComponent<Props> = ({ pageContext }) => {
-  const data: MainMenuData = useStaticQuery(graphql`
-    query MainMenuQuery {
-      contentfulSiteSite {
-        contentful_id
-
-        mainMenu {
-          contentful_id
-          title
-          flavor
-          layout
-
-          links {
-            contentful_id
-            label
-            type
-
-            toPage {
-              contentful_id
-            }
-          }
-        }
-      }
-    }
-  `)
-
-  const { mainMenu } = data.contentfulSiteSite
-  const links: NavLinkItem[] = []
-  if (mainMenu && mainMenu.links) {
-    mainMenu.links.forEach((link) => {
-      if (!link || !link.label || !link.toPage) {
-        return
-      }
-      const navLink: NavLinkItem = {
-        title: link.label,
-        path: pageContext.pageLookup[link.toPage.contentful_id].path,
-      }
-      links.push(navLink)
-    })
-  }
+const MainMenu: FunctionComponent = () => {
+  const linksHardcoded: NavLinkItem[] = [
+    {
+      title: 'Home',
+      path: '/',
+    },
+    {
+      title: 'Who We Are',
+      path: '/who-we-are/',
+    },
+    {
+      title: 'What We Do',
+      path: '/what-we-do',
+    },
+    {
+      title: 'Get Involved',
+      path: '/get-involved',
+    },
+  ]
 
   return (
     <header className="py-2 bg-navy-800 h-nav sticky top-0">
       <div className="max-w-5xl px-4 mx-auto h-full flex items-center justify-between">
-        <MobileNavigation navLinks={links} />
+        <MobileNavigation navLinks={linksHardcoded} />
         <div className="flex items-center w-16 h-16">
-          <Link
-            to="/"
-            className="text-white w-full h-full"
-            aria-label="Go to the home page"
-          >
-            <BrandMark flavor="white" layout="logo" className="block" />
+          <Link to="/" className="text-white" aria-label="Go to the home page">
+            <BrandMark flavor="white" layout="logo" />
           </Link>
         </div>
-        <DesktopNavigation navLinks={links} />
+        <DesktopNavigation navLinks={linksHardcoded} />
       </div>
     </header>
   )

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -31,7 +31,7 @@ const DefaultLayout: FunctionComponent<Props> = ({ pageContext, children }) => {
 
       {/* site level header / body / footer */}
       <header>
-        <MainMenu pageContext={pageContext} />
+        <MainMenu />
         <Breadcrumbs pageContext={pageContext} />
       </header>
       <main>{children}</main>

--- a/src/layouts/Simple.tsx
+++ b/src/layouts/Simple.tsx
@@ -28,7 +28,7 @@ const SimpleLayout: FunctionComponent<Props> = ({ pageContext, children }) => {
       {/* site level header / body / footer */}
       <header>
         {/*
-          <MainMenu pageContext={pageContext} />
+          <MainMenu />
           <Breadcrumbs pageContext={pageContext} />
         */}
         Site Header


### PR DESCRIPTION
I decided to hard-code the navigation until we have a working prototype for the website. I feel like this will speed up development by reducing complexity, and we can build it up again when we need it.

I also fixed the size of the Distribute Aid logo:

<img width="1054" alt="Screen Shot 2021-11-15 at 6 40 09 PM" src="https://user-images.githubusercontent.com/3411183/141886145-beb6dbb3-5c69-4667-83c3-95ea4880cf38.png">

