### PR TITLE
Build the mobile timeline for the About Us page

### DIFF
--- a/src/components/about-us/AboutHero.tsx
+++ b/src/components/about-us/AboutHero.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react'
+
+const AboutHero: FC = () => (
+  <div className="py-8 md:py-20 mx-auto" style={{ maxWidth: 800 }}>
+    <div
+      style={{
+        position: 'relative',
+        paddingBottom: '56.5%',
+        paddingTop: 30,
+        height: 0,
+        overflow: 'hidden',
+      }}
+    >
+      <iframe
+        className="max-w-full"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+        }}
+        src="https://www.youtube.com/embed/msizPweg3kE"
+        title="YouTube video player"
+        frameBorder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  </div>
+)
+
+export default AboutHero

--- a/src/components/about-us/AboutOurMission.tsx
+++ b/src/components/about-us/AboutOurMission.tsx
@@ -1,0 +1,34 @@
+import React, { FC } from 'react'
+
+const AboutOurMission: FC = () => (
+  <section className="bg-gray-50">
+    <div className="max-w-5xl mx-auto px-4 py-12 lg:py-20 space-y-6 text-lg text-gray-700">
+      <h2 className="text-2xl font-semibold mb-8 text-gray-800">
+        About our mission
+      </h2>
+      <p>
+        We are re-imagining humanitarian aid delivery. We aim to help move{' '}
+        <strong>humanitarian aid</strong> to where it is needed most, create an{' '}
+        <strong>efficient</strong> and <strong>time-saving</strong> system for
+        shipments of aid, and <strong>lower carbon emissions</strong> for
+        humanitarian aid. Distribute Aid has the end goal of producing a
+        platform for the use of aid collection and service providing groups that
+        will incorporate all of these aims seamlessly. We offer support to a
+        huge network of grassroots organisations working within the Refugee Aid
+        movement in Europe, and COVID-19 response groups in Europe and the US.
+      </p>
+      <p>
+        Distribute Aid wants to bring more transparency to all groups involved
+        around what donations are on offer, and make it easier to see what is
+        needed where, which also prevents waste. Creating a platform for aid
+        delivery will connect hundreds of independent groups working in the same
+        field, for the same greater cause but who currently have little
+        oversight. This platform will also provide a way to collect data on
+        regional needs, providing a wider overview of needs and assist in
+        securing in-kind donations to a scale never before possible!
+      </p>
+    </div>
+  </section>
+)
+
+export default AboutOurMission

--- a/src/components/about-us/BoardMembers.tsx
+++ b/src/components/about-us/BoardMembers.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react'
+import boardSrc from '../../images/about-us/board.jpg'
+
+const BoardMembers: FC = () => (
+  <div className="max-w-7xl mx-auto text-center py-20 px-4 text-lg">
+    <img
+      className="mx-auto mb-4"
+      style={{
+        width: 600,
+        height: 300,
+        objectFit: 'cover',
+        objectPosition: 'top',
+      }}
+      width="600"
+      height="300"
+      src={boardSrc}
+      alt="Our board members from left to right: Rudayna Abdo, Sara Lönegård, and Stephanie Fairbank"
+    />
+    <p className="text-gray-600">
+      Our board members from left to right:
+      <br />
+      Rudayna Abdo, Sara Lönegård, and Stephanie Fairbank
+    </p>
+  </div>
+)
+
+export default BoardMembers

--- a/src/components/about-us/History.tsx
+++ b/src/components/about-us/History.tsx
@@ -1,0 +1,59 @@
+import { FC } from 'react'
+
+const historyContent = [
+  {
+    period: 'Summer 2018',
+    content:
+      'When sorting donations in Scotland Sara had the idea for Distribute Aid to make it easier for people to help',
+  },
+  {
+    period: 'Fall 2018',
+    content:
+      'Sara and Taylor (co-founders) spent 3 months visiting and volunteering with 50+ aid organisations in Europe to discover the most effective ways to help',
+  },
+  {
+    period: 'January 2019',
+    content: 'Distribute Aid became a registered charity in Sweden',
+  },
+  {
+    period: 'October 2019',
+    content: 'Distribute Aid facilitated its first large in-kind donation',
+  },
+  {
+    period: 'January 2020',
+    content:
+      'Distribute Aid received the "Most Direct Human Impact" award by the UN Technology and Innovation Lab',
+  },
+  {
+    period: 'March 2020',
+    content:
+      'Flexport.org rewarded Distribute Aid with a $50,000 grant to provide emergency aid shipments',
+  },
+  {
+    period: 'Fall 2020',
+    content:
+      'Distribute Aid facilitated the international response to the Moria fire, tripling its number of aid shipments to date',
+  },
+  {
+    period: 'Spring 2021',
+    content:
+      'Distribute Aid set up aid hubs and regular routes from the U.K. to help grassroots organisations continue to send aid after Brexit.',
+  },
+]
+
+const History: FC = () => {
+  return (
+    <section>
+      <div className="history-container">
+        {historyContent.map((item, i) => (
+          <div key={`item-${i}`} className="history-item">
+            <p className="text-xl text-navy-600 font-bold">{item.period}</p>
+            <p>{item.content}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default History

--- a/src/components/about-us/MissionStatement.tsx
+++ b/src/components/about-us/MissionStatement.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react'
+import logoBlueSrc from '../../images/logomark_blue.svg'
+
+const MissionStatement: FC = () => (
+  <section className="bg-navy-50 px-4 py-20">
+    <div className="max-w-5xl mx-auto">
+      <div className="space-y-6 text-navy-700 text-2xl lg:text-3xl lg:leading-snug">
+        <div className="lg:flex justify-between items-center lg:space-x-8">
+          <img
+            className="mx-auto my-6"
+            width="130"
+            height="60"
+            src={logoBlueSrc}
+            alt="Distribute Aid Logo: A flock of doves stylized by stacking wings behind the main outline of a dove."
+          />
+          <p className="flex-grow">
+            Distribute Aid’s mission is to provide for basic human needs at
+            scale by connecting communities and empowering people to uphold
+            human dignity.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+)
+
+export default MissionStatement

--- a/src/components/about-us/Timeline.tsx
+++ b/src/components/about-us/Timeline.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-const historyContent = [
+const timelineContent = [
   {
     period: 'Summer 2018',
     content:
@@ -41,19 +41,23 @@ const historyContent = [
   },
 ]
 
-const History: FC = () => {
-  return (
-    <section>
-      <div className="history-container">
-        {historyContent.map((item, i) => (
-          <div key={`item-${i}`} className="history-item">
-            <p className="text-xl text-navy-600 font-bold">{item.period}</p>
-            <p>{item.content}</p>
-          </div>
-        ))}
-      </div>
-    </section>
-  )
-}
+const Timeline: FC = () => (
+  <section className="px-4 pt-20 max-w-6xl mx-auto">
+    <h2 className="text-4xl font-semibold mb-4">Our history</h2>
+    <div className="timeline-container">
+      {timelineContent.map((item, i) => (
+        <div
+          key={`item-${i}`}
+          className={`timeline-item ${i % 2 === 0 ? 'left' : 'right'}`}
+        >
+          <p className="text-xl text-navy-600 font-bold mb-2 timeline-title">
+            {item.period}
+          </p>
+          <p>{item.content}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+)
 
-export default History
+export default Timeline

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -1,107 +1,17 @@
 import { FC } from 'react'
-import logoBlueSrc from '../images/logomark_blue.svg'
-import boardSrc from '../images/about-us/board.jpg'
 import SimpleLayout from '@layouts/Simple'
+import AboutHero from '@components/about-us/AboutHero'
+import MissionStatement from '@components/about-us/MissionStatement'
+import BoardMembers from '@components/about-us/BoardMembers'
+import AboutOurMission from '@components/about-us/AboutOurMission'
 import Timeline from '@components/about-us/Timeline'
 
 const AboutUs: FC = () => (
   <SimpleLayout pageTitle="About us">
-    <div className="py-8 md:py-20 mx-auto" style={{ maxWidth: 800 }}>
-      <div
-        style={{
-          position: 'relative',
-          paddingBottom: '56.5%',
-          paddingTop: 30,
-          height: 0,
-          overflow: 'hidden',
-        }}
-      >
-        <iframe
-          className="max-w-full"
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-          }}
-          src="https://www.youtube.com/embed/msizPweg3kE"
-          title="YouTube video player"
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-        />
-      </div>
-    </div>
-    <section className="bg-navy-50 px-4 py-20">
-      <div className="max-w-5xl mx-auto">
-        <div className="space-y-6 text-navy-700 text-2xl lg:text-3xl lg:leading-snug">
-          <div className="lg:flex justify-between items-center lg:space-x-8">
-            <img
-              className="mx-auto my-6"
-              width="130"
-              height="60"
-              src={logoBlueSrc}
-              alt="Distribute Aid Logo: A flock of doves stylized by stacking wings behind the main outline of a dove."
-            />
-            <p className="flex-grow">
-              Distribute Aid’s mission is to provide for basic human needs at
-              scale by connecting communities and empowering people to uphold
-              human dignity.
-            </p>
-          </div>
-        </div>
-      </div>
-    </section>
-    <div className="max-w-7xl mx-auto text-center py-20 px-4 text-lg">
-      <img
-        className="mx-auto mb-4"
-        style={{
-          width: 600,
-          height: 300,
-          objectFit: 'cover',
-          objectPosition: 'top',
-        }}
-        width="600"
-        height="300"
-        src={boardSrc}
-        alt="Our board members from left to right: Rudayna Abdo, Sara Lönegård, and Stephanie Fairbank"
-      />
-      <p>
-        Our board members from left to right:
-        <br />
-        Rudayna Abdo, Sara Lönegård, and Stephanie Fairbank
-      </p>
-    </div>
-    <section className="bg-gray-50">
-      <div className="max-w-5xl mx-auto px-4 py-12 lg:py-20 space-y-6 text-lg text-gray-700">
-        <h2 className="text-2xl font-semibold mb-8 text-gray-800">
-          About our mission
-        </h2>
-        <p>
-          We are re-imagining humanitarian aid delivery. We aim to help move{' '}
-          <strong>humanitarian aid</strong> to where it is needed most, create
-          an <strong>efficient</strong> and <strong>time-saving</strong> system
-          for shipments of aid, and <strong>lower carbon emissions</strong> for
-          humanitarian aid. Distribute Aid has the end goal of producing a
-          platform for the use of aid collection and service providing groups
-          that will incorporate all of these aims seamlessly. We offer support
-          to a huge network of grassroots organisations working within the
-          Refugee Aid movement in Europe, and COVID-19 response groups in Europe
-          and the US.
-        </p>
-        <p>
-          Distribute Aid wants to bring more transparency to all groups involved
-          around what donations are on offer, and make it easier to see what is
-          needed where, which also prevents waste. Creating a platform for aid
-          delivery will connect hundreds of independent groups working in the
-          same field, for the same greater cause but who currently have little
-          oversight. This platform will also provide a way to collect data on
-          regional needs, providing a wider overview of needs and assist in
-          securing in-kind donations to a scale never before possible!
-        </p>
-      </div>
-    </section>
+    <AboutHero />
+    <MissionStatement />
+    <BoardMembers />
+    <AboutOurMission />
     <Timeline />
   </SimpleLayout>
 )

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import logoBlueSrc from '../images/logomark_blue.svg'
 import boardSrc from '../images/about-us/board.jpg'
 import SimpleLayout from '@layouts/Simple'
-import History from '@components/about-us/History'
+import Timeline from '@components/about-us/Timeline'
 
 const AboutUs: FC = () => (
   <SimpleLayout pageTitle="About us">
@@ -102,7 +102,7 @@ const AboutUs: FC = () => (
         </p>
       </div>
     </section>
-    <History />
+    <Timeline />
   </SimpleLayout>
 )
 

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -1,86 +1,109 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 import logoBlueSrc from '../images/logomark_blue.svg'
 import boardSrc from '../images/about-us/board.jpg'
 import SimpleLayout from '@layouts/Simple'
+import History from '@components/about-us/History'
 
-const cardClasses = 'p-4 max-w-xl mx-auto flex flex-col items-center space-y-4'
-
-const AboutUs: FC = () => {
-  const [modalIsOpen, setModalIsOpen] = useState(false)
-
-  return (
-    <SimpleLayout pageTitle="About us">
+const AboutUs: FC = () => (
+  <SimpleLayout pageTitle="About us">
+    <div className="py-8 md:py-20 mx-auto" style={{ maxWidth: 800 }}>
       <div
-        className="pt-8 md:pt-20 max-w-7xl mx-auto"
-        style={{ minHeight: '80vh' }}
+        style={{
+          position: 'relative',
+          paddingBottom: '56.5%',
+          paddingTop: 30,
+          height: 0,
+          overflow: 'hidden',
+        }}
       >
-        <div
+        <iframe
+          className="max-w-full"
           style={{
-            position: 'relative',
-            paddingBottom: '56.5%',
-            paddingTop: 30,
-            height: 0,
-            overflow: 'hidden',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
           }}
-        >
-          <iframe
-            className="max-w-full"
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              height: '100%',
-            }}
-            src="https://www.youtube.com/embed/msizPweg3kE"
-            title="YouTube video player"
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          />
-        </div>
+          src="https://www.youtube.com/embed/msizPweg3kE"
+          title="YouTube video player"
+          frameBorder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
       </div>
-      <section className="bg-navy-50 px-4 py-20">
-        <div className="max-w-7xl mx-auto">
-          <div className="space-y-6 text-navy-700 text-2xl lg:text-3xl lg:leading-snug">
-            <div className="lg:flex justify-between items-center lg:space-x-8">
-              <img
-                width="130"
-                height="60"
-                src={logoBlueSrc}
-                alt="Distribute Aid Logo: A flock of doves stylized by stacking wings behind the main outline of a dove."
-              />
-              <p className="flex-grow">
-                Distribute Aid’s mission is to provide for basic human needs at
-                scale by connecting communities and empowering people to uphold
-                human dignity.
-              </p>
-            </div>
+    </div>
+    <section className="bg-navy-50 px-4 py-20">
+      <div className="max-w-5xl mx-auto">
+        <div className="space-y-6 text-navy-700 text-2xl lg:text-3xl lg:leading-snug">
+          <div className="lg:flex justify-between items-center lg:space-x-8">
+            <img
+              className="mx-auto my-6"
+              width="130"
+              height="60"
+              src={logoBlueSrc}
+              alt="Distribute Aid Logo: A flock of doves stylized by stacking wings behind the main outline of a dove."
+            />
+            <p className="flex-grow">
+              Distribute Aid’s mission is to provide for basic human needs at
+              scale by connecting communities and empowering people to uphold
+              human dignity.
+            </p>
           </div>
         </div>
-      </section>
-      <div className="max-w-7xl mx-auto text-center py-20 px-4 text-lg">
-        <img
-          className="mx-auto mb-4"
-          style={{
-            width: 600,
-            height: 300,
-            objectFit: 'cover',
-            objectPosition: 'top',
-          }}
-          width="600"
-          height="300"
-          src={boardSrc}
-          alt="Our board members from left to right: Rudayna Abdo, Sara Lönegård, and Stephanie Fairbank"
-        />
+      </div>
+    </section>
+    <div className="max-w-7xl mx-auto text-center py-20 px-4 text-lg">
+      <img
+        className="mx-auto mb-4"
+        style={{
+          width: 600,
+          height: 300,
+          objectFit: 'cover',
+          objectPosition: 'top',
+        }}
+        width="600"
+        height="300"
+        src={boardSrc}
+        alt="Our board members from left to right: Rudayna Abdo, Sara Lönegård, and Stephanie Fairbank"
+      />
+      <p>
+        Our board members from left to right:
+        <br />
+        Rudayna Abdo, Sara Lönegård, and Stephanie Fairbank
+      </p>
+    </div>
+    <section className="bg-gray-50">
+      <div className="max-w-5xl mx-auto px-4 py-12 lg:py-20 space-y-6 text-lg text-gray-700">
+        <h2 className="text-2xl font-semibold mb-8 text-gray-800">
+          About our mission
+        </h2>
         <p>
-          Our board members from left to right:
-          <br />
-          Rudayna Abdo, Sara Lönegård, and Stephanie Fairbank
+          We are re-imagining humanitarian aid delivery. We aim to help move{' '}
+          <strong>humanitarian aid</strong> to where it is needed most, create
+          an <strong>efficient</strong> and <strong>time-saving</strong> system
+          for shipments of aid, and <strong>lower carbon emissions</strong> for
+          humanitarian aid. Distribute Aid has the end goal of producing a
+          platform for the use of aid collection and service providing groups
+          that will incorporate all of these aims seamlessly. We offer support
+          to a huge network of grassroots organisations working within the
+          Refugee Aid movement in Europe, and COVID-19 response groups in Europe
+          and the US.
+        </p>
+        <p>
+          Distribute Aid wants to bring more transparency to all groups involved
+          around what donations are on offer, and make it easier to see what is
+          needed where, which also prevents waste. Creating a platform for aid
+          delivery will connect hundreds of independent groups working in the
+          same field, for the same greater cause but who currently have little
+          oversight. This platform will also provide a way to collect data on
+          regional needs, providing a wider overview of needs and assist in
+          securing in-kind donations to a scale never before possible!
         </p>
       </div>
-    </SimpleLayout>
-  )
-}
+    </section>
+    <History />
+  </SimpleLayout>
+)
 
 export default AboutUs

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -44,3 +44,52 @@
 .link {
   @apply text-navy-700 hover:underline font-semibold;
 }
+
+.history-container {
+  position: relative;
+}
+
+.history-container::after {
+  @apply bg-gray-200;
+  content: '';
+  display: block;
+  height: 100%;
+  left: calc(1rem - 1px);
+  position: absolute;
+  top: 0;
+  width: 2px;
+  z-index: 1;
+}
+
+.history-item {
+  margin: 1rem 0 1rem 4rem;
+  position: relative;
+}
+
+/* the dot */
+.history-item::after {
+  @apply border-navy-500 border-2;
+  background: white;
+  border-radius: 50%;
+  content: '';
+  display: block;
+  height: 8px;
+  left: calc(-4px - 3rem);
+  position: absolute;
+  top: 0.75rem;
+  width: 8px;
+  z-index: 3;
+}
+
+/* the horizontal line */
+.history-item::before {
+  @apply bg-navy-500;
+  content: '';
+  display: block;
+  height: 2px;
+  left: -3rem;
+  position: absolute;
+  top: calc(0.75rem + 3px);
+  width: 2rem;
+  z-index: 2;
+}

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -6,6 +6,7 @@
 @import './burger.css';
 @import './routes.css';
 @import './nav.css';
+@import './timeline.css';
 
 .team-page-container {
   width: 70%;
@@ -43,53 +44,4 @@
 
 .link {
   @apply text-navy-700 hover:underline font-semibold;
-}
-
-.history-container {
-  position: relative;
-}
-
-.history-container::after {
-  @apply bg-gray-200;
-  content: '';
-  display: block;
-  height: 100%;
-  left: calc(1rem - 1px);
-  position: absolute;
-  top: 0;
-  width: 2px;
-  z-index: 1;
-}
-
-.history-item {
-  margin: 1rem 0 1rem 4rem;
-  position: relative;
-}
-
-/* the dot */
-.history-item::after {
-  @apply border-navy-500 border-2;
-  background: white;
-  border-radius: 50%;
-  content: '';
-  display: block;
-  height: 8px;
-  left: calc(-4px - 3rem);
-  position: absolute;
-  top: 0.75rem;
-  width: 8px;
-  z-index: 3;
-}
-
-/* the horizontal line */
-.history-item::before {
-  @apply bg-navy-500;
-  content: '';
-  display: block;
-  height: 2px;
-  left: -3rem;
-  position: absolute;
-  top: calc(0.75rem + 3px);
-  width: 2rem;
-  z-index: 2;
 }

--- a/src/stylesheets/timeline.css
+++ b/src/stylesheets/timeline.css
@@ -1,0 +1,157 @@
+/*
+
+On mobile, the timeline is stacked on the left side of the screen:
+
+│
+├─── Title
+│    Paragraph of content
+│
+├─── Title
+│    Paragraph of content
+│
+├─── Title
+│    Paragraph of content
+│
+
+On wider monitors, the timeline items alternate between the left and right:
+
+                         │
+                         │
+Title  ──────────────────┤
+Paragraph of content     │
+                         │
+                         ├─── Title
+                         │    Paragraph of content
+                         │
+Long title   ────────────┤
+Paragraph of content     │
+                         │
+                         ├─── Title
+                         │    Paragraph of content
+                         │
+
+We use pseudo-elements to display the lines and circles.
+
+For wider displays, we render 2 horizontal lines for the .timeline-item
+containers on the left side of the screen, because we want to extend the lines
+toward the titles. To achieve that, we render an extra horizontal line inside
+the .timeline-title.
+
+ */
+
+.timeline-container {
+  --line-color: #e5e7eb;
+  --line-accent-color: #8b9fc8;
+
+  padding: 1rem 0;
+  position: relative;
+}
+
+.timeline-container::after {
+  background: var(--line-color);
+  content: '';
+  display: block;
+  height: 100%;
+  left: calc(0.5rem - 1px);
+  position: absolute;
+  top: 0;
+  width: 2px;
+  z-index: 1;
+}
+
+/* Each timeline item contains a title and some content. */
+.timeline-item {
+  margin: 2rem 0 2rem 3rem;
+  position: relative;
+}
+
+/* On wider displays, the timeline titles use a pseudo-element to extend the
+vertical line toward the text. */
+.timeline-title {
+  align-items: center;
+  display: flex;
+  height: 28px; /* fixed width so that the horizontal lines are placed reliably */
+}
+
+/* the dot */
+.timeline-item::after {
+  background: white;
+  border-radius: 50%;
+  border: 2px solid var(--line-accent-color);
+  content: '';
+  display: block;
+  height: 8px;
+  left: calc(-4px - 2.5rem);
+  position: absolute;
+  top: calc(14px - 4px);
+  width: 8px;
+  z-index: 3;
+}
+
+/* the horizontal lines */
+.timeline-item::before {
+  background-color: var(--line-accent-color);
+  content: '';
+  display: block;
+  height: 2px;
+  left: -2.5rem;
+  position: absolute;
+  top: calc(14px - 1px);
+  width: 2rem;
+  z-index: 2;
+}
+
+@media (min-width: 1024px) {
+  .timeline-container {
+    padding: 4rem 0;
+  }
+
+  /* Display the vertical line in the center */
+  .timeline-container::after {
+    left: calc(50% - 1px);
+  }
+
+  /* Align the items to the right of the timeline */
+  .timeline-item.right {
+    margin-left: auto;
+    width: calc(50% - 3rem);
+  }
+
+  /* The horizontal lines for items on the left side */
+  .timeline-item.left {
+    margin-left: 0;
+    width: calc(50% - 3rem);
+  }
+
+  /* The dots for items on the left side */
+  .timeline-item.left::after {
+    left: auto;
+    right: calc(-3rem - 4px);
+  }
+
+  /* The dots for items on the right side */
+  .timeline-item.right::after {
+    left: calc(-4px - 3rem);
+  }
+
+  /* The horizontal lines on the left side */
+  .timeline-item.left::before {
+    left: auto;
+    right: calc(-3rem - 1px);
+    width: 4rem;
+  }
+
+  /* The horizontal lines fon the right side */
+  .timeline-item.right::before {
+    left: -3rem;
+  }
+
+  /* Torizontal lines after titles on the left side */
+  .timeline-item.left .timeline-title::after {
+    background-color: var(--line-accent-color);
+    content: '';
+    flex: 1;
+    height: 2px;
+    margin-left: 2rem;
+  }
+}


### PR DESCRIPTION
Build the rest of the "About Us" page, including a few paragraphs about our mission and a timeline of major events in the history of Distribute Aid.

This PR resolves #111.

![Screen Shot 2021-12-05 at 11 24 05-fullpage](https://user-images.githubusercontent.com/3411183/144760593-cf5d7234-d157-4864-80a3-18a55a754324.png)
