### PR TITLE
Simplify the video on the About Us page

### DIFF
--- a/src/components/about-us/AboutHero.tsx
+++ b/src/components/about-us/AboutHero.tsx
@@ -2,31 +2,17 @@ import { FC } from 'react'
 
 const AboutHero: FC = () => (
   <div className="py-8 md:py-20 mx-auto" style={{ maxWidth: 800 }}>
-    <div
+    <iframe
       style={{
-        position: 'relative',
-        paddingBottom: '56.5%',
-        paddingTop: 30,
-        height: 0,
-        overflow: 'hidden',
+        aspectRatio: '16/9',
+        width: '100%',
       }}
-    >
-      <iframe
-        className="max-w-full"
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-        }}
-        src="https://www.youtube.com/embed/msizPweg3kE"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowFullScreen
-      />
-    </div>
+      src="https://www.youtube.com/embed/msizPweg3kE"
+      title="YouTube video player"
+      frameBorder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
   </div>
 )
 


### PR DESCRIPTION
I recently learned about the new `aspect-ratio` property, which allows us to simplify the CSS for responsive YouTube videos!

[Learn more here](https://dev.to/deammer/embed-responsive-youtube-videos-in-2021-5dkh).