### PR TITLE
Use gatsby-image-plugin to RoutesSection

### DIFF
--- a/src/components/home/RouteCard.tsx
+++ b/src/components/home/RouteCard.tsx
@@ -7,7 +7,7 @@ type Props = {
   subtitle: ReactNode
   ctaLabel: ReactNode
   ctaUrl: string
-  imageSrc: string
+  image: ReactNode
 }
 
 const RouteCard: FC<Props> = ({
@@ -16,15 +16,10 @@ const RouteCard: FC<Props> = ({
   subtitle,
   ctaLabel,
   ctaUrl,
-  imageSrc,
+  image,
 }) => (
   <article className="border">
-    <img
-      src={imageSrc}
-      alt=""
-      className="mb-4 object-cover w-full"
-      style={{ height: 200 }}
-    />
+    {image}
     <div className="text-center">
       <h2 className="text-xl font-semibold mb-1">{title}</h2>
       <p className="text-gray-600 mb-6">{subtitle}</p>

--- a/src/components/home/RoutesSection.tsx
+++ b/src/components/home/RoutesSection.tsx
@@ -1,9 +1,7 @@
 import React, { FC } from 'react'
+import { StaticImage } from 'gatsby-plugin-image'
 import RouteCard from '@components/home/RouteCard'
 import InternalLink from '@components/link/InternalLink'
-import franceRouteImage from '../../images/home/help-refugees-warehouse-calais.jpg'
-import lebanonRouteImage from '../../images/home/the-free-shop-unloading.jpg'
-import customShipmentsImage from '../../images/home/bobby-moving-a-pallet-iha.jpg'
 
 const RoutesSection: FC = () => (
   <section className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 px-4 lg:px-8 py-12 lg:py-24 max-w-7xl mx-auto">
@@ -11,8 +9,15 @@ const RoutesSection: FC = () => (
       title="UK ➜ France"
       subtitle="Pallets via DA Delivery"
       ctaLabel="Ship aid to France!"
-      ctaUrl="/routes/uk-to-france/"
-      imageSrc={franceRouteImage}
+      ctaUrl="/routes/uk-to-francie/"
+      image={
+        <StaticImage
+          src={'../../images/home/help-refugees-warehouse-calais.jpg'}
+          alt="Calais warehouse"
+          className="mb-4 object-cover w-full"
+          height={200}
+        />
+      }
     >
       <p>Send pallets to Calais & Dunkirk on our monthly truck.</p>
       <p>
@@ -32,7 +37,14 @@ const RoutesSection: FC = () => (
       subtitle="Pallets via DA Delivery"
       ctaLabel="Ship aid to Lebanon!"
       ctaUrl="/routes/uk-to-lebanon/"
-      imageSrc={lebanonRouteImage}
+      image={
+        <StaticImage
+          src={'../../images/home/the-free-shop-unloading.jpg'}
+          alt="Two volunteers unloading a truck"
+          className="mb-4 object-cover w-full"
+          height={200}
+        />
+      }
     >
       <p>Send pallets to Calais & Dunkirk on our monthly truck.</p>
       <p>
@@ -45,7 +57,14 @@ const RoutesSection: FC = () => (
       subtitle="Pallets, Trucks, & Containers"
       ctaLabel="Contact Us!"
       ctaUrl="mailto:logistics@distributeaid.org"
-      imageSrc={customShipmentsImage}
+      image={
+        <StaticImage
+          src={'../../images/home/bobby-moving-a-pallet-iha.jpg'}
+          alt="Volunteer Bobby moving a pallet"
+          className="mb-4 object-cover w-full"
+          height={200}
+        />
+      }
     >
       <p>
         We're happy to help organize or advise on humanitarian aid shipments to:


### PR DESCRIPTION
Hi! I was just curious to see if I could implement site speed improvements in a quick and easy way (answer: not really)

This should already improve it a little bit.

I did find out the following though:

[gatsby-plugin-image](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/) exposes two components:
* StaticImage: Use this if the image is the same every time the component is used. Examples: site logo, index page hero image
* GatsbyImage: Use this if the image is passed into the component as a prop, or otherwise changes. Examples: Blog post hero image, author avatar

In most cases for this codebase, the `GatsbyImage` component would be the nicest. The only problem is that the images that could use some improvements are not coming from contentful, but they are coming from a file. This forces us to use `StaticImage`.

But this also means that [we cannot pass the image src as a prop](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/#restrictions-on-using-staticimage). (Which is why I went for render props in this example.)

The images that I saw were now mostly being complained about in the lighthouse test are the 'how we help' images.
But that has a reusable component. And like mentioned before: passing a src doesn't work there (booo :( ).

So either we can also do a little bit of a hacky render props thing there as well. Or those sections would be passed to contentful, so `GatsbyImage` can do its graphql magic on them.

Like @jtfairbank mentioned in the stream: I can imagine this might be something for a later moment. But at least now you have some extra info on limitations :) 

![seal slowly moving away](https://media.giphy.com/media/AmDzMmCJZABsk/giphy.gif)