### PR TITLE
Fix the video size in browsers that don't support aspect-ratio

### DIFF
--- a/src/components/about-us/AboutHero.tsx
+++ b/src/components/about-us/AboutHero.tsx
@@ -2,17 +2,16 @@ import { FC } from 'react'
 
 const AboutHero: FC = () => (
   <div className="py-8 md:py-20 mx-auto" style={{ maxWidth: 800 }}>
-    <iframe
-      style={{
-        aspectRatio: '16/9',
-        width: '100%',
-      }}
-      src="https://www.youtube.com/embed/msizPweg3kE"
-      title="YouTube video player"
-      frameBorder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-      allowFullScreen
-    />
+    <div className="video-container">
+      <iframe
+        className="video-iframe"
+        src="https://www.youtube.com/embed/msizPweg3kE"
+        title="YouTube video player"
+        frameBorder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
   </div>
 )
 

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -46,23 +46,22 @@
   @apply text-navy-700 hover:underline font-semibold;
 }
 
-.video-container {
-  /* Fallback for browsers that don't support aspect-ratio */
-  @supports not (aspect-ratio: 1 / 1) {
+.video-iframe {
+  aspect-ratio: 16/9;
+  width: 100%;
+}
+
+/* Fallback for browsers that don't support aspect-ratio */
+@supports not (aspect-ratio: auto) {
+  .video-container {
     position: relative;
     padding-bottom: 56.25%;
     padding-top: 30px;
     height: 0;
     overflow: hidden;
   }
-}
 
-.video-iframe {
-  aspect-ratio: 16/9;
-  width: 100%;
-
-  /* Fallback for browsers that don't support aspect-ratio */
-  @supports not (aspect-ratio: 1 / 1) {
+  .video-iframe {
     position: absolute;
     top: 0;
     left: 0;

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -48,7 +48,7 @@
 
 .video-container {
   /* Fallback for browsers that don't support aspect-ratio */
-  @supports not (aspect-ratio: auto) {
+  @supports not (aspect-ratio: 1 / 1) {
     position: relative;
     padding-bottom: 56.25%;
     padding-top: 30px;
@@ -56,12 +56,13 @@
     overflow: hidden;
   }
 }
+
 .video-iframe {
   aspect-ratio: 16/9;
   width: 100%;
 
   /* Fallback for browsers that don't support aspect-ratio */
-  @supports not (aspect-ratio: auto) {
+  @supports not (aspect-ratio: 1 / 1) {
     position: absolute;
     top: 0;
     left: 0;

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -45,3 +45,27 @@
 .link {
   @apply text-navy-700 hover:underline font-semibold;
 }
+
+.video-container {
+  /* Fallback for browsers that don't support aspect-ratio */
+  @supports not (aspect-ratio: auto) {
+    position: relative;
+    padding-bottom: 56.25%;
+    padding-top: 30px;
+    height: 0;
+    overflow: hidden;
+  }
+}
+.video-iframe {
+  aspect-ratio: 16/9;
+  width: 100%;
+
+  /* Fallback for browsers that don't support aspect-ratio */
+  @supports not (aspect-ratio: auto) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}


### PR DESCRIPTION
Added a fallback for older browsers that don't support the `aspect-ratio` property.

|Before|After|
|---|---|
|![Screenshot 2022-01-11 at 09 21 15](https://user-images.githubusercontent.com/3411183/149830950-bd565dd2-716a-451d-b1ed-8508c885967d.png)|<img width="1054" alt="Screen Shot 2022-01-17 at 12 02 18 PM" src="https://user-images.githubusercontent.com/3411183/149830893-8a87cdd6-1458-4a0e-823c-23a3f081a718.png">|


