### PR TITLE
Pull data from the site-settings file

### DIFF
--- a/.forestry/settings.yml
+++ b/.forestry/settings.yml
@@ -2,27 +2,27 @@
 new_page_extension: md
 auto_deploy: false
 admin_path: ''
-webhook_url: 
+webhook_url:
 sections:
-- type: directory
-  path: content/pages
-  label: Pages
-  create: all
-  match: "**/*"
-- type: document
-  path: content/site-settings.yml
-  label: Site Settings
+  - type: directory
+    path: content/pages
+    label: Pages
+    create: all
+    match: '**/*'
+  - type: document
+    path: content/site-settings.json
+    label: Site Settings
 upload_dir: content/uploads
-public_path: "/uploads"
+public_path: '/uploads'
 front_matter_path: ''
 use_front_matter_path: false
-file_template: ":filename:"
+file_template: ':filename:'
 build:
   preview_env:
-  - DISABLE_CODESEE_INSTRUMENTATION=1
+    - DISABLE_CODESEE_INSTRUMENTATION=1
   preview_output_directory: public
   install_dependencies_command: yarn install
   preview_docker_image: node:14
-  mount_path: "/srv"
-  working_dir: "/srv"
+  mount_path: '/srv'
+  working_dir: '/srv'
   instant_preview_command: yarn forestry:preview

--- a/content/site-settings.json
+++ b/content/site-settings.json
@@ -1,0 +1,7 @@
+{
+  "instagramUrl": "https://www.instagram.com/distributeaid",
+  "twitterUrl": "https://twitter.com/DistributeAid",
+  "linkedinUrl": "https://www.linkedin.com/company/distribute-aid",
+  "facebookUrl": "https://www.facebook.com/DistributeAidDotOrg/",
+  "footerEmail": "hello@distributeaid.org"
+}

--- a/content/site-settings.yml
+++ b/content/site-settings.yml
@@ -1,5 +1,0 @@
-instagramUrl: 'https://www.instagram.com/distributeaid'
-twitterUrl: 'https://twitter.com/DistributeAid'
-linkedinUrl: 'https://www.linkedin.com/company/distribute-aid'
-facebookUrl: 'https://www.facebook.com/DistributeAidDotOrg/'
-footerEmail: 'hello@distributeaid.org'

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import ExternalLink from '@components/link/ExternalLink'
 import { Link } from 'gatsby'
+import siteSettings from '../../content/site-settings.json'
 import SocialIconContainer from './social-media/SocialIconContainer'
 
 const Footer: FC = () => (
@@ -17,8 +18,11 @@ const Footer: FC = () => (
     <div className="my-4">
       <p>
         Email us at{' '}
-        <ExternalLink className="link" href="mailto:hello@distributeaid.org">
-          hello@distributeaid.org
+        <ExternalLink
+          className="link"
+          href={`mailto:${siteSettings.footerEmail}`}
+        >
+          {siteSettings.footerEmail}
           <span className="sr-only">(opens in your email client)</span>
         </ExternalLink>
       </p>

--- a/src/components/social-media/SocialIconContainer.tsx
+++ b/src/components/social-media/SocialIconContainer.tsx
@@ -1,5 +1,6 @@
 import { FC, useEffect, useState } from 'react'
 
+import siteSettings from '../../../content/site-settings.json'
 import facebookSrc from '../../images/social-icons/facebook.svg'
 import twitterSrc from '../../images/social-icons/twitter.svg'
 import linkedInSrc from '../../images/social-icons/linked-in.svg'
@@ -9,22 +10,22 @@ import { getThemeLargeScreenWidth } from 'utils/site-theme'
 
 const socialMediaDetails = [
   {
-    href: 'https://www.instagram.com/distributeaid',
+    href: siteSettings.instagramUrl,
     src: instagramSrc,
     altText: 'Instagram icon',
   },
   {
-    href: 'https://twitter.com/DistributeAid',
+    href: siteSettings.twitterUrl,
     src: twitterSrc,
     altText: 'Twitter icon',
   },
   {
-    href: 'https://www.linkedin.com/company/distribute-aid',
+    href: siteSettings.linkedinUrl,
     src: linkedInSrc,
     altText: 'LinkedIn icon',
   },
   {
-    href: 'https://www.facebook.com/DistributeAidDotOrg/',
+    href: siteSettings.facebookUrl,
     src: facebookSrc,
     altText: 'Facebook icon',
   },


### PR DESCRIPTION
We're now pulling data from the `site-settings.json` file. I changed the extension from `.yml` to `.json` because it's easier for Gatsby to parse.