### PR TITLE
Mobile responsiveness for routes pages

### DIFF
--- a/src/components/routes/RoutesSectionImage.tsx
+++ b/src/components/routes/RoutesSectionImage.tsx
@@ -1,0 +1,17 @@
+import { FunctionComponent, ReactNode } from 'react'
+
+interface Props {
+  image: string
+  ariaLabel: string
+}
+
+const RoutesSectionImage: FunctionComponent<Props> = ({ image, ariaLabel }) => (
+  <div
+    role="img"
+    aria-label={ariaLabel}
+    className="bg-center-center bg-no-repeat bg-cover bg-slate-200 w-full md:w-2/4 h-96 md:h-auto"
+    style={{ backgroundImage: `url(${image})` }}
+  ></div>
+)
+
+export default RoutesSectionImage

--- a/src/components/routes/RoutesSectionImage.tsx
+++ b/src/components/routes/RoutesSectionImage.tsx
@@ -9,7 +9,7 @@ const RoutesSectionImage: FunctionComponent<Props> = ({ image, ariaLabel }) => (
   <div
     role="img"
     aria-label={ariaLabel}
-    className="bg-center-center bg-no-repeat bg-cover bg-slate-200 w-full md:w-2/4 h-96 md:h-auto"
+    className="bg-center bg-no-repeat bg-cover bg-slate-200 w-full md:w-2/4 h-96 md:h-auto"
     style={{ backgroundImage: `url(${image})` }}
   ></div>
 )

--- a/src/components/routes/TextWithVisual.tsx
+++ b/src/components/routes/TextWithVisual.tsx
@@ -1,0 +1,27 @@
+import { FunctionComponent, ReactNode } from 'react'
+
+interface Props {
+  id?: string
+  positionOfVisual: 'left' | 'right'
+  children: ReactNode
+  visual: ReactNode
+}
+
+const TextWithVisual: FunctionComponent<Props> = ({
+  id,
+  positionOfVisual,
+  children,
+  visual,
+}) => (
+  <section
+    className={`text-navy-700 section flex flex-col md:flex-row ${
+      positionOfVisual === 'left' ? 'md:flex-row-reverse' : ''
+    }`}
+    {...(id && { id })}
+  >
+    <div className="p-4 bg-white w-full md:w-2/4 ">{children}</div>
+    {visual}
+  </section>
+)
+
+export default TextWithVisual

--- a/src/pages/routes/uk-to-france.tsx
+++ b/src/pages/routes/uk-to-france.tsx
@@ -470,7 +470,7 @@ const UkToFrance: FC = () => {
         positionOfVisual="right"
         visual={
           <RoutesSectionImage
-            ariaLabel="Pallets with lots of cans of food."
+            ariaLabel="Pallets with lots of cans of food and a person celebrating the successful unloading."
             image={calaisUnloadingBackground}
           />
         }

--- a/src/pages/routes/uk-to-france.tsx
+++ b/src/pages/routes/uk-to-france.tsx
@@ -17,524 +17,157 @@ import collectionBackground from './collection-and-sorting.jpg'
 import mobileRefugeeSupportBackground from './mobile-refugee-support-distribution.jpg'
 import calaisUnloadingBackground from './calais-food-collective-unloading.jpg'
 import SimpleLayout from '@layouts/Simple'
+import TextWithVisual from '../../components/routes/TextWithVisual'
+import RoutesSectionImage from '../../components/routes/RoutesSectionImage'
 
 const UkToFrance: FC = () => {
   return (
     <SimpleLayout pageTitle="Route: UK to France">
-      <section
-        className="text-navy-700 section section--above-the-fold flex justify-start items-stretch section--content-left bg--img-cover bg--img-forklift-loading"
-        style={{ backgroundImage: `url(${forkliftLoadingBackground})` }}
-      >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h1 className="section__title">
-              <img
-                width="130"
-                height="60"
-                src={logoSrc}
-                alt="Distribute Aid Logo: A flock of doves stylized by stacking wings behind the main outline of a dove."
-              />
-              <span>Delivery</span>
-            </h1>
-            <h2 className="text-2xl">Regular Route: UK&rarr;France</h2>
-          </header>
-
-          <div className="section__body">
-            <p className="mb-4">
-              Distribute Aid is organising a regular route for humanitarian aid
-              shipments between the UK and France. We won't let pandemics,
-              Brexit, or global supply chain disruptions stop the flow of aid to
-              those who need it most! &#9829;
-            </p>
-            <p className="mb-4">
-              If you're here because you want to donate goods for people on the
-              move in France-{' '}
-              <strong className="text-uppercase">thank you!</strong> Groups on
-              the ground would not be able to provide the services they do
-              without support from donations like yours.
-            </p>
-
-            <div className="tiles tiles--grid tiles--highlight">
-              <div className="tile tile--column w-1/2">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={netIcon}
-                    alt="Hub Icon: Multiple nodes connected to a center hub."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">1 UK Staging Hubs</p>
-                  <p>Cambridge</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/2">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={mapIcon}
-                    alt="Map Icon: A destination marker on a map."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Service to Calais &amp; Dunkirk</p>
-                  <p>Supporting 7 Frontline Groups</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/2">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={truckIcon}
-                    alt="Truck Icon: A truck in motion."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Regular Shipments</p>
-                  <p>Scaled To Demand</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/2">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={heartBillIcon}
-                    alt="Money Icon: A currency bill with a heart in the middle."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Fair Flat-Rate Pricing</p>
-                  <p>All-Inclusive, At-Cost</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <footer>
-            <p className="photo-credit text-center">
-              <span>Background Photo Credit:</span>{' '}
-              <a
-                href="https://www.facebook.com/groups/hertsforrefugees/permalink/3488608217903521/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Mark Lampert of Herts For Refugees
-              </a>
-            </p>
-          </footer>
-        </div>
-      </section>
-
-      <section
-        id="reserve-your-spot"
-        className="text-navy-700 section section--content-right bg--img-cover bg--img-pallet-storage"
-        style={{ backgroundImage: `url(${palletStorageBackground})` }}
-      >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h2 className="section__title">Reserve Your Spot!</h2>
-          </header>
-
-          <div className="section__body">
-            <ol className="">
-              <li className="">
-                <h4 className="text-lg font-semibold mb-4">
-                  1) Submit Your Aid Delivery Request
-                </h4>
-                <p className="mb-4">
-                  Download the{' '}
-                  <a
-                    className="stage-action"
-                    // TODO host this resource
-                    href="/docs/da_aid-delivery-request_uk-to-france.xlsx"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Aid Delivery Request Form
-                  </a>{' '}
-                  and fill it in.
-                </p>
-                <p className="mb-4">
-                  Email the completed form to{' '}
-                  <a
-                    className="stage-action"
-                    href="mailto:hubs@distributeaid.org"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    hubs@distributeaid.org
-                  </a>
-                  . Your local Staging Hub will receive it and follow up if
-                  there are any questions.
-                </p>
-                <p className="h5">Submissions Close: 31st October</p>
-              </li>
-              <li className="stage">
-                <h4 className="text-lg font-semibold mb-4">
-                  2) Consult Frontline Groups
-                </h4>
-                <p className="mb-4">
-                  We'll check in with the frontline groups during the offer
-                  period, to confirm which offered donations they want and to
-                  prioritise deliveries that meet their biggest needs. Then we
-                  can confirm if you have a place reserved on the next truck.
-                </p>
-                <p className="h5">Latest Confirmation Date: 5th November</p>
-              </li>
-              <li className="stage">
-                <h4 className="text-lg font-semibold mb-4">
-                  3) Drop Off @ Staging Hubs
-                </h4>
-                <p className="mb-4">
-                  Schedule a drop-off appointment with your local Staging Hub,
-                  pay them the flat-rate{' '}
-                  <a href="#storage-and-shipping-charge">
-                    Storage &amp; Shipping charge
-                  </a>
-                  , and deliver the boxes of aid at the agreed time.
-                </p>
-                <p className="h5">Staging Period: 15th - 22nd November</p>
-              </li>
-              <li className="stage">
-                <h4 className="text-lg font-semibold mb-4">
-                  4) Deliver The Aid
-                </h4>
-                <p className="mb-4">
-                  <strong>And that's it!</strong> Take an evening off to
-                  celebrate a job well done, we got it from here. Once your aid
-                  is delivered we'll follow up with an after-shipment report,
-                  including photos and acknowledgments from the frontline
-                  groups.
-                </p>
-                <p className="h5">Truck Departs: 23rd November</p>
-              </li>
-              <li className="stage">
-                <h4 className="text-lg font-semibold mb-4">
-                  Shipment Timetable
-                </h4>
-                <table className="w-full">
-                  <thead>
-                    <tr>
-                      <th className="border-b-2 border-gray-100 p-2"></th>
-                      <th className="border-b-2 border-gray-100 p-2">
-                        Offer Deadline
-                      </th>
-                      <th className="border-b-2 border-gray-100 p-2">
-                        Truck Departs
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr className="border-b border-gray-100 bg-gray-50">
-                      <td className="p-2"></td>
-                      <td className="p-2">8th August</td>
-                      <td className="p-2">24th August</td>
-                    </tr>
-                    <tr className="border-b border-gray-100">
-                      <td className="p-2"></td>
-                      <td className="p-2">12th September</td>
-                      <td className="p-2">5th October</td>
-                    </tr>
-                    <tr className="border-b border-gray-100 bg-gray-50">
-                      <td className="text-center text-lg p-2">
-                        <strong>&#10148;</strong>
-                      </td>
-                      <td className="p-2">31st October</td>
-                      <td className="p-2">15th November</td>
-                    </tr>
-                    <tr className="border-b border-gray-100">
-                      <td className="p-2"></td>
-                      <td className="p-2">28th November</td>
-                      <td className="p-2">13th December</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </li>
-            </ol>
-          </div>
-
-          <footer>
-            <p className="photo-credit text-center">
-              <span>Background Photo Credit:</span>{' '}
-              <a href="https://unsplash.com/@ruchindra?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">
-                Ruchindra Gunasekara
-              </a>{' '}
-              <span>
-                on{' '}
-                <a href="https://unsplash.com/s/photos/warehouse?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">
-                  Unsplash
-                </a>
-              </span>
-            </p>
-          </footer>
-        </div>
-      </section>
-
-      <section
-        id="frontline-groups"
-        className="text-navy-700 section flex justify-start items-stretch section--content-left bg--img-cover bg--img-mrs-distro"
-        style={{ backgroundImage: `url(${mobileRefugeeSupportBackground})` }}
-      >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h2 className="section__title">Frontline Groups</h2>
-          </header>
-
-          <div className="section__body">
-            <div className="tiles tiles--grid ">
-              <div className="tile tile--column w-1/3">
-                <div className="tile-icon mx-auto">
-                  <StaticImage
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/mrs-logo.256.jpg"
-                    alt="Frontline Group Logo: Mobile Refugee Support (MRS)"
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Mobile Refugee Support</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/3">
-                <div className="tile-icon mx-auto">
-                  <StaticImage
-                    className="icon icon--responsive rounded-full"
-                    src="../../images/regular-routes/ca-logo.256.jpg"
-                    alt="Frontline Group Logo: Collective Aid (CA)"
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Collective Aid</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/3">
-                <div className="tile-icon mx-auto">
-                  <StaticImage
-                    className="icon icon--responsive rounded-full"
-                    src="../../images/regular-routes/u56-logo.256.jpg"
-                    alt="Frontline Group Logo: Utopia 56 (U56)"
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Utopia 56</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/3">
-                <div className="tile-icon mx-auto">
-                  <StaticImage
-                    className="icon icon--responsive rounded-full"
-                    src="../../images/regular-routes/cfc-logo.256.jpg"
-                    alt="Frontline Group Logo: Calais Food Collective (CFC)"
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Calais Food Collective</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/3">
-                <div className="tile-icon mx-auto">
-                  <StaticImage
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/rck-logo.256.jpg"
-                    alt="Frontline Group Logo: Refugee Community Kitchen (RCK)"
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Refugee Community Kitchen</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/3">
-                <div className="tile-icon mx-auto">
-                  <StaticImage
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/rwc-logo.256.jpg"
-                    alt="Frontline Group Logo: Refugee Women's Center (RWC)"
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Refugee Women's Center</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/3">
-                <div className="tile-icon mx-auto">
-                  <StaticImage
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/auberge-logo.256.jpg"
-                    alt="Frontline Group Logo: L'Auberge des Migrants (Auberge)"
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">L'Auberge des Migrants</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <footer>
-            <p className="photo-credit text-center hide-sm">
-              <span>Background Photo Credit:</span>{' '}
-              <a
-                href="https://www.facebook.com/MobileRefugeeSupport/posts/1492064960999110"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Mobile Refugee Support
-              </a>
-            </p>
-          </footer>
-        </div>
-      </section>
-
-      <div className="flex">
-        <div className="w-full md:w-1/2">
-          <iframe
-            src="https://www.google.com/maps/d/u/0/embed?mid=1a1ZBC-Fc-WJCP27ZGx70YFRaAByjdFTS"
-            width="100%"
-            height="100%"
+      <TextWithVisual
+        positionOfVisual="right"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="Fork lift loading pallets into a truck"
+            image={forkliftLoadingBackground}
           />
-        </div>
+        }
+      >
+        <header className="my-4 text-center">
+          <h1 className="section__title">
+            <img
+              width="130"
+              height="60"
+              src={logoSrc}
+              alt="Distribute Aid Logo: A flock of doves stylized by stacking wings behind the main outline of a dove."
+            />
+            <span>Delivery</span>
+          </h1>
+          <h2 className="text-2xl">Regular Route: UK&rarr;France</h2>
+        </header>
 
-        <section
-          id="uk-staging-hubs"
-          className="text-navy-700 section w-full md:w-1/2"
-        >
-          <div className="section__content bg-white">
-            <header className="mb-4 text-center">
-              <h1 className="section__title">UK Staging Hubs</h1>
-            </header>
+        <div className="section__body">
+          <p className="mb-4">
+            Distribute Aid is organising a regular route for humanitarian aid
+            shipments between the UK and France. We won't let pandemics, Brexit,
+            or global supply chain disruptions stop the flow of aid to those who
+            need it most! &#9829;
+          </p>
+          <p className="mb-4">
+            If you're here because you want to donate goods for people on the
+            move in France-{' '}
+            <strong className="text-uppercase">thank you!</strong> Groups on the
+            ground would not be able to provide the services they do without
+            support from donations like yours.
+          </p>
 
-            <div className="section__body">
-              <p className="mb-4">
-                The most{' '}
-                <strong>cost efficient and Brexit / pandemic-proof</strong> way
-                to send aid from the UK to France is by shipping palletised aid
-                on articulated lorries that are loaded by a forklift.{' '}
-                <strong>That's where our UK Staging Hubs come in!</strong> They
-                have the necessary infrastructure and experience working with us
-                to ensure each shipment is fully optimized, which everybody
-                benefits from. Once it's in a Staging Hub, your aid will be
-                palletised, stored, and loaded by a forklift onto the next
-                truck.
-              </p>
-
-              <div className="mb-12 flex">
-                <div className="tile-icon">
-                  <StaticImage
-                    src="../../images/regular-routes/pallet-aid-logo.256.png"
-                    alt="Hub Logo: Pallet Aid (PA)"
-                    height={80}
-                    width={80}
-                  />
-                </div>
-                <div className="tile-content ml-4">
-                  <p className="text-lg font-medium mb-2">
-                    Cambridge - South England
-                  </p>
-                  <p className="text-sm leading-snug">
-                    Both Community &amp; Commercial Aid
-                  </p>
-                  <p className="text-sm leading-snug">
-                    pallets, loose boxes, bulk bags of tents &amp; sleeping
-                    bags, etc
-                  </p>
-                </div>
+          <div className="tiles tiles--grid tiles--highlight">
+            <div className="tile tile--column w-1/2">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={netIcon}
+                  alt="Hub Icon: Multiple nodes connected to a center hub."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">1 UK Staging Hubs</p>
+                <p>Cambridge</p>
               </div>
             </div>
 
-            <footer>
-              <p className="photo-credit text-center">
-                Questions? Comments? Contact us all at{' '}
+            <div className="tile tile--column w-1/2">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={mapIcon}
+                  alt="Map Icon: A destination marker on a map."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Service to Calais &amp; Dunkirk</p>
+                <p>Supporting 7 Frontline Groups</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/2">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={truckIcon}
+                  alt="Truck Icon: A truck in motion."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Regular Shipments</p>
+                <p>Scaled To Demand</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/2">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={heartBillIcon}
+                  alt="Money Icon: A currency bill with a heart in the middle."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Fair Flat-Rate Pricing</p>
+                <p>All-Inclusive, At-Cost</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer>
+          <p className="photo-credit text-center">
+            <span>Background Photo Credit:</span>{' '}
+            <a
+              href="https://www.facebook.com/groups/hertsforrefugees/permalink/3488608217903521/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Mark Lampert of Herts For Refugees
+            </a>
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="reserve-your-spot"
+        positionOfVisual="left"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="An aisle in a warehouse with shelves stacked high with pallets of boxes."
+            image={palletStorageBackground}
+          />
+        }
+      >
+        <header className="mb-4 text-center">
+          <h2 className="section__title">Reserve Your Spot!</h2>
+        </header>
+
+        <div className="section__body">
+          <ol className="">
+            <li className="">
+              <h4 className="text-lg font-semibold mb-4">
+                1) Submit Your Aid Delivery Request
+              </h4>
+              <p className="mb-4">
+                Download the{' '}
                 <a
-                  href="mailto:hubs@distributeaid.org"
+                  className="stage-action"
+                  // TODO host this resource
+                  href="/docs/da_aid-delivery-request_uk-to-france.xlsx"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  hubs@distributeaid.org
-                </a>
-                .
+                  Aid Delivery Request Form
+                </a>{' '}
+                and fill it in.
               </p>
-            </footer>
-          </div>
-        </section>
-      </div>
-
-      <section
-        id="storage-and-shipping-charge"
-        className="text-navy-700 section flex justify-start items-stretch section--content-left bg--img-cover bg--img-cfc-unloading"
-        style={{ backgroundImage: `url(${calaisUnloadingBackground})` }}
-      >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h1 className="section__title">Storage &amp; Shipping (£)</h1>
-          </header>
-
-          <div className="section__body">
-            <p>
-              We offer a flat, per-pallet and per-box storage and shipment
-              charge (S&amp;S) to take the stress out of budgeting to move your
-              aid. By using the Staging Hubs we can keep shipping costs low and
-              consistent, and spread the cost evenly for all groups sending aid.
-            </p>
-
-            <div className="tiles tiles--row ">
-              <div className="tile tile--column">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={palletIcon}
-                    alt="Standard Pallet Icon: Four boxes stacked evenly on a pallet."
-                  />
-                </div>
-                <div className="tile-content text-left">
-                  <p className="mb-1">Standard Pallet - £75</p>
-                  <p>1.2m x 1.0m x 1.70m high</p>
-                  <p>700kg</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={halfPalletIcon}
-                    alt="Half Pallet Icon: 3 boxes stacked in a pyramid on a pallet."
-                  />
-                </div>
-                <div className="tile-content text-left">
-                  <p className="mb-1">Half Pallet - £45</p>
-                  <p>1.2m x 1.0m x 0.85m high</p>
-                  <p>350kg</p>
-                </div>
-              </div>
-            </div>
-
-            <h3>What if my aid doesn't fit exactly?</h3>
-
-            <ul>
-              <li>
-                We encourage groups to work together to submit a combined offer
-                that makes up a Standard Pallet or Half Pallet worth of aid.
-              </li>
-              <li>
-                We reserve 2 pallets worth of space on each truck for overflow,
-                so if you have slightly more then a Standard Pallet's worth of
-                aid that's ok! Overflow pricing is £2.50 per banana box (500mm x
-                400mm x 250mm high, holds 15kg).
-              </li>
-              <li>
-                You'll still need to book a Standard Pallet space for
-                commercially purchased aid with smaller pallet dimensions.
-                Unfortunately, due to the way trucks are packed a smaller pallet
-                size doesn't actually allow us to fit more on there. You can
-                always contact{' '}
+              <p className="mb-4">
+                Email the completed form to{' '}
                 <a
                   className="stage-action"
                   href="mailto:hubs@distributeaid.org"
@@ -542,144 +175,513 @@ const UkToFrance: FC = () => {
                   rel="noopener noreferrer"
                 >
                   hubs@distributeaid.org
-                </a>{' '}
-                to look into booking a full truck load at a custom rate.
-              </li>
-              <li>
-                We can book you multiple Standard Pallets worth of space to
-                accommodate bulky items. Please submit the exact dimensions of
-                the item on the offer form so we can assess how many Standard
-                Pallets it will require, and ensure that we book a curtain-side
-                truck to load it.
-              </li>
-            </ul>
-          </div>
-
-          <footer>
-            <p className="photo-credit text-center">
-              <span>Background Photo Credit:</span>{' '}
-              <a
-                href="https://www.instagram.com/calais_food_collective/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Calais Food Collective
-              </a>
-            </p>
-          </footer>
+                </a>
+                . Your local Staging Hub will receive it and follow up if there
+                are any questions.
+              </p>
+              <p className="h5">Submissions Close: 31st October</p>
+            </li>
+            <li className="stage">
+              <h4 className="text-lg font-semibold mb-4">
+                2) Consult Frontline Groups
+              </h4>
+              <p className="mb-4">
+                We'll check in with the frontline groups during the offer
+                period, to confirm which offered donations they want and to
+                prioritise deliveries that meet their biggest needs. Then we can
+                confirm if you have a place reserved on the next truck.
+              </p>
+              <p className="h5">Latest Confirmation Date: 5th November</p>
+            </li>
+            <li className="stage">
+              <h4 className="text-lg font-semibold mb-4">
+                3) Drop Off @ Staging Hubs
+              </h4>
+              <p className="mb-4">
+                Schedule a drop-off appointment with your local Staging Hub, pay
+                them the flat-rate{' '}
+                <a href="#storage-and-shipping-charge">
+                  Storage &amp; Shipping charge
+                </a>
+                , and deliver the boxes of aid at the agreed time.
+              </p>
+              <p className="h5">Staging Period: 15th - 22nd November</p>
+            </li>
+            <li className="stage">
+              <h4 className="text-lg font-semibold mb-4">4) Deliver The Aid</h4>
+              <p className="mb-4">
+                <strong>And that's it!</strong> Take an evening off to celebrate
+                a job well done, we got it from here. Once your aid is delivered
+                we'll follow up with an after-shipment report, including photos
+                and acknowledgments from the frontline groups.
+              </p>
+              <p className="h5">Truck Departs: 23rd November</p>
+            </li>
+            <li className="stage">
+              <h4 className="text-lg font-semibold mb-4">Shipment Timetable</h4>
+              <table className="w-full">
+                <thead>
+                  <tr>
+                    <th className="border-b-2 border-gray-100 p-2"></th>
+                    <th className="border-b-2 border-gray-100 p-2">
+                      Offer Deadline
+                    </th>
+                    <th className="border-b-2 border-gray-100 p-2">
+                      Truck Departs
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-gray-100 bg-gray-50">
+                    <td className="p-2"></td>
+                    <td className="p-2">8th August</td>
+                    <td className="p-2">24th August</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="p-2"></td>
+                    <td className="p-2">12th September</td>
+                    <td className="p-2">5th October</td>
+                  </tr>
+                  <tr className="border-b border-gray-100 bg-gray-50">
+                    <td className="text-center text-lg p-2">
+                      <strong>&#10148;</strong>
+                    </td>
+                    <td className="p-2">31st October</td>
+                    <td className="p-2">15th November</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="p-2"></td>
+                    <td className="p-2">28th November</td>
+                    <td className="p-2">13th December</td>
+                  </tr>
+                </tbody>
+              </table>
+            </li>
+          </ol>
         </div>
-      </section>
 
-      <section
-        id="all-about-pallets"
-        className="text-navy-700 section section--content-right bg--img-cover bg--img-collection-and-sorting"
-        style={{ backgroundImage: `url(${collectionBackground})` }}
+        <footer>
+          <p className="photo-credit text-center">
+            <span>Background Photo Credit:</span>{' '}
+            <a href="https://unsplash.com/@ruchindra?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">
+              Ruchindra Gunasekara
+            </a>{' '}
+            <span>
+              on{' '}
+              <a href="https://unsplash.com/s/photos/warehouse?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">
+                Unsplash
+              </a>
+            </span>
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="frontline-groups"
+        positionOfVisual="right"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="Mobile refugee support station with a few people gathering."
+            image={mobileRefugeeSupportBackground}
+          />
+        }
       >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h1 className="section__title">All About Pallets</h1>
-          </header>
-
-          <div className="section__body">
-            <h3>How many Standard Pallet spaces do I need?</h3>
-
-            <div className="tiles tiles--column ">
-              <div className="tile flex">
-                <div className="tile-icon w-20 flex-shrink-0">
-                  <img
-                    className="icon icon--responsive"
-                    src={vanIcon}
-                    alt="Van Icon: The Calais classic."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Van Loads</p>
-                  <p>
-                    The Calais classic. Most Vans fit about{' '}
-                    <strong>3 Standard Pallets</strong> worth of aid in the
-                    back.
-                  </p>
-                </div>
+        <header className="mb-4 text-center">
+          <h2 className="section__title">Frontline Groups</h2>
+        </header>
+        <div className="section__body">
+          <div className="tiles tiles--grid ">
+            <div className="tile tile--column w-1/3">
+              <div className="tile-icon mx-auto">
+                <StaticImage
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/mrs-logo.256.jpg"
+                  alt="Frontline Group Logo: Mobile Refugee Support (MRS)"
+                />
               </div>
-              <div className="tile flex">
-                <div className="tile-icon w-20 flex-shrink-0">
-                  <img
-                    className="icon icon--responsive"
-                    src={sackIcon}
-                    alt="Bulk Bag Icon: A large sack."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Bulk Bags</p>
-                  <p>
-                    Perfect for those larger, clumsier items like tents or
-                    sleeping bags that are too awkward to box up.
-                  </p>
-                  <ul className="">
-                    <li>
-                      Each Bulk Bag takes up one <strong>Half Pallet</strong>{' '}
-                      space.
-                    </li>
-                    <li>
-                      2 Bulk Bags count as a <strong>Standard Pallet</strong> if
-                      they can be stacked.
-                    </li>
-                    <li>
-                      A <strong>Standard Pallet</strong> can also be made by
-                      stacking a Bulk Bag on top of 18 Banana Boxes.
-                    </li>
-                  </ul>
-                </div>
+              <div className="tile-content">
+                <p className="mb-1">Mobile Refugee Support</p>
               </div>
-              <div className="tile flex">
-                <div className="tile-icon w-20 flex-shrink-0">
-                  <img
-                    className="icon icon--responsive"
-                    src={boxIcon}
-                    alt="Confirmed Box Icon: The proverbial banana box."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Banana Boxes</p>
-                  <p>
-                    Easy to acquire, small, and sturdy boxes. Each Banana Box
-                    should hold a specific item, such as mens small pants or
-                    women's medium winter sweaters. Any consistently sized box
-                    could be used to fill a Standard or Half pallet. Banana Box
-                    sizes can vary a bit, but a good rule of thumb is:
-                  </p>
-                  <ul className="">
-                    <li>
-                      <strong>Dimensions:</strong> 500mm x 400mm x 250mm high,
-                      holds 15kg
-                    </li>
-                    <li>
-                      18 Banana Boxes make up a <strong>Half Pallet</strong>
-                    </li>
-                    <li>
-                      36 Banana Boxes can fit on a{' '}
-                      <strong>Standard Pallet</strong>
-                    </li>
-                  </ul>
-                </div>
+            </div>
+
+            <div className="tile tile--column w-1/3">
+              <div className="tile-icon mx-auto">
+                <StaticImage
+                  className="icon icon--responsive rounded-full"
+                  src="../../images/regular-routes/ca-logo.256.jpg"
+                  alt="Frontline Group Logo: Collective Aid (CA)"
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Collective Aid</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/3">
+              <div className="tile-icon mx-auto">
+                <StaticImage
+                  className="icon icon--responsive rounded-full"
+                  src="../../images/regular-routes/u56-logo.256.jpg"
+                  alt="Frontline Group Logo: Utopia 56 (U56)"
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Utopia 56</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/3">
+              <div className="tile-icon mx-auto">
+                <StaticImage
+                  className="icon icon--responsive rounded-full"
+                  src="../../images/regular-routes/cfc-logo.256.jpg"
+                  alt="Frontline Group Logo: Calais Food Collective (CFC)"
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Calais Food Collective</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/3">
+              <div className="tile-icon mx-auto">
+                <StaticImage
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/rck-logo.256.jpg"
+                  alt="Frontline Group Logo: Refugee Community Kitchen (RCK)"
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Refugee Community Kitchen</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/3">
+              <div className="tile-icon mx-auto">
+                <StaticImage
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/rwc-logo.256.jpg"
+                  alt="Frontline Group Logo: Refugee Women's Center (RWC)"
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Refugee Women's Center</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/3">
+              <div className="tile-icon mx-auto">
+                <StaticImage
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/auberge-logo.256.jpg"
+                  alt="Frontline Group Logo: L'Auberge des Migrants (Auberge)"
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">L'Auberge des Migrants</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer>
+          <p className="photo-credit text-center hide-sm">
+            <span>Background Photo Credit:</span>{' '}
+            <a
+              href="https://www.facebook.com/MobileRefugeeSupport/posts/1492064960999110"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Mobile Refugee Support
+            </a>
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="uk-staging-hubs"
+        positionOfVisual="left"
+        visual={
+          <iframe
+            className="w-full md:w-2/4 h-96 md:h-auto"
+            src="https://www.google.com/maps/d/u/0/embed?mid=1a1ZBC-Fc-WJCP27ZGx70YFRaAByjdFTS"
+            width="100%"
+            height="100%"
+          />
+        }
+      >
+        <header className="mb-4 text-center">
+          <h1 className="section__title">UK Staging Hubs</h1>
+        </header>
+
+        <div className="section__body">
+          <p className="mb-4">
+            The most <strong>cost efficient and Brexit / pandemic-proof</strong>{' '}
+            way to send aid from the UK to France is by shipping palletised aid
+            on articulated lorries that are loaded by a forklift.{' '}
+            <strong>That's where our UK Staging Hubs come in!</strong> They have
+            the necessary infrastructure and experience working with us to
+            ensure each shipment is fully optimized, which everybody benefits
+            from. Once it's in a Staging Hub, your aid will be palletised,
+            stored, and loaded by a forklift onto the next truck.
+          </p>
+
+          <div className="mb-12 flex">
+            <div className="tile-icon">
+              <StaticImage
+                src="../../images/regular-routes/pallet-aid-logo.256.png"
+                alt="Hub Logo: Pallet Aid (PA)"
+                height={80}
+                width={80}
+              />
+            </div>
+            <div className="tile-content ml-4">
+              <p className="text-lg font-medium mb-2">
+                Cambridge - South England
+              </p>
+              <p className="text-sm leading-snug">
+                Both Community &amp; Commercial Aid
+              </p>
+              <p className="text-sm leading-snug">
+                pallets, loose boxes, bulk bags of tents &amp; sleeping bags,
+                etc
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <footer>
+          <p className="photo-credit text-center">
+            Questions? Comments? Contact us all at{' '}
+            <a
+              href="mailto:hubs@distributeaid.org"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              hubs@distributeaid.org
+            </a>
+            .
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="storage-and-shipping-charge"
+        positionOfVisual="right"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="Pallets with lots of cans of food."
+            image={calaisUnloadingBackground}
+          />
+        }
+      >
+        <header className="mb-4 text-center">
+          <h1 className="section__title">Storage &amp; Shipping (£)</h1>
+        </header>
+
+        <div className="section__body">
+          <p>
+            We offer a flat, per-pallet and per-box storage and shipment charge
+            (S&amp;S) to take the stress out of budgeting to move your aid. By
+            using the Staging Hubs we can keep shipping costs low and
+            consistent, and spread the cost evenly for all groups sending aid.
+          </p>
+
+          <div className="tiles tiles--row ">
+            <div className="tile tile--column">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={palletIcon}
+                  alt="Standard Pallet Icon: Four boxes stacked evenly on a pallet."
+                />
+              </div>
+              <div className="tile-content text-left">
+                <p className="mb-1">Standard Pallet - £75</p>
+                <p>1.2m x 1.0m x 1.70m high</p>
+                <p>700kg</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={halfPalletIcon}
+                  alt="Half Pallet Icon: 3 boxes stacked in a pyramid on a pallet."
+                />
+              </div>
+              <div className="tile-content text-left">
+                <p className="mb-1">Half Pallet - £45</p>
+                <p>1.2m x 1.0m x 0.85m high</p>
+                <p>350kg</p>
               </div>
             </div>
           </div>
 
-          <footer>
-            <p className="photo-credit text-center hide-sm">
-              <span>Background Photo Credit:</span>{' '}
+          <h3>What if my aid doesn't fit exactly?</h3>
+
+          <ul>
+            <li>
+              We encourage groups to work together to submit a combined offer
+              that makes up a Standard Pallet or Half Pallet worth of aid.
+            </li>
+            <li>
+              We reserve 2 pallets worth of space on each truck for overflow, so
+              if you have slightly more then a Standard Pallet's worth of aid
+              that's ok! Overflow pricing is £2.50 per banana box (500mm x 400mm
+              x 250mm high, holds 15kg).
+            </li>
+            <li>
+              You'll still need to book a Standard Pallet space for commercially
+              purchased aid with smaller pallet dimensions. Unfortunately, due
+              to the way trucks are packed a smaller pallet size doesn't
+              actually allow us to fit more on there. You can always contact{' '}
               <a
-                href="https://www.facebook.com/DGRefugeeAction"
+                className="stage-action"
+                href="mailto:hubs@distributeaid.org"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Jay Rubenstien of Massive Outpouring of Love
-              </a>
-            </p>
-          </footer>
+                hubs@distributeaid.org
+              </a>{' '}
+              to look into booking a full truck load at a custom rate.
+            </li>
+            <li>
+              We can book you multiple Standard Pallets worth of space to
+              accommodate bulky items. Please submit the exact dimensions of the
+              item on the offer form so we can assess how many Standard Pallets
+              it will require, and ensure that we book a curtain-side truck to
+              load it.
+            </li>
+          </ul>
         </div>
-      </section>
+
+        <footer>
+          <p className="photo-credit text-center">
+            <span>Background Photo Credit:</span>{' '}
+            <a
+              href="https://www.instagram.com/calais_food_collective/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Calais Food Collective
+            </a>
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="all-about-pallets"
+        positionOfVisual="left"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="Three people sorting and packing clothes into boxes."
+            image={collectionBackground}
+          />
+        }
+      >
+        <header className="mb-4 text-center">
+          <h1 className="section__title">All About Pallets</h1>
+        </header>
+        <div className="section__body">
+          <h3>How many Standard Pallet spaces do I need?</h3>
+
+          <div className="tiles tiles--column ">
+            <div className="tile flex">
+              <div className="tile-icon w-20 flex-shrink-0">
+                <img
+                  className="icon icon--responsive"
+                  src={vanIcon}
+                  alt="Van Icon: The Calais classic."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Van Loads</p>
+                <p>
+                  The Calais classic. Most Vans fit about{' '}
+                  <strong>3 Standard Pallets</strong> worth of aid in the back.
+                </p>
+              </div>
+            </div>
+            <div className="tile flex">
+              <div className="tile-icon w-20 flex-shrink-0">
+                <img
+                  className="icon icon--responsive"
+                  src={sackIcon}
+                  alt="Bulk Bag Icon: A large sack."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Bulk Bags</p>
+                <p>
+                  Perfect for those larger, clumsier items like tents or
+                  sleeping bags that are too awkward to box up.
+                </p>
+                <ul className="">
+                  <li>
+                    Each Bulk Bag takes up one <strong>Half Pallet</strong>{' '}
+                    space.
+                  </li>
+                  <li>
+                    2 Bulk Bags count as a <strong>Standard Pallet</strong> if
+                    they can be stacked.
+                  </li>
+                  <li>
+                    A <strong>Standard Pallet</strong> can also be made by
+                    stacking a Bulk Bag on top of 18 Banana Boxes.
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <div className="tile flex">
+              <div className="tile-icon w-20 flex-shrink-0">
+                <img
+                  className="icon icon--responsive"
+                  src={boxIcon}
+                  alt="Confirmed Box Icon: The proverbial banana box."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Banana Boxes</p>
+                <p>
+                  Easy to acquire, small, and sturdy boxes. Each Banana Box
+                  should hold a specific item, such as mens small pants or
+                  women's medium winter sweaters. Any consistently sized box
+                  could be used to fill a Standard or Half pallet. Banana Box
+                  sizes can vary a bit, but a good rule of thumb is:
+                </p>
+                <ul className="">
+                  <li>
+                    <strong>Dimensions:</strong> 500mm x 400mm x 250mm high,
+                    holds 15kg
+                  </li>
+                  <li>
+                    18 Banana Boxes make up a <strong>Half Pallet</strong>
+                  </li>
+                  <li>
+                    36 Banana Boxes can fit on a{' '}
+                    <strong>Standard Pallet</strong>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer>
+          <p className="photo-credit text-center hide-sm">
+            <span>Background Photo Credit:</span>{' '}
+            <a
+              href="https://www.facebook.com/DGRefugeeAction"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Jay Rubenstien of Massive Outpouring of Love
+            </a>
+          </p>
+        </footer>
+      </TextWithVisual>
     </SimpleLayout>
   )
 }

--- a/src/pages/routes/uk-to-lebanon.tsx
+++ b/src/pages/routes/uk-to-lebanon.tsx
@@ -18,482 +18,154 @@ import settlementLebanonBackground from './informal-tented-settlement-lebanon.jp
 import forkliftLoadingBackground from './forklift-loading-2.jpg'
 import collectionBackground from './collection-and-sorting.jpg'
 import SimpleLayout from '@layouts/Simple'
+import TextWithVisual from '../../components/routes/TextWithVisual'
+import RoutesSectionImage from '../../components/routes/RoutesSectionImage'
 
 const UkToLebanon: FC = () => {
   return (
     <SimpleLayout pageTitle="Route: UK to Lebanon">
-      <section
-        className="text-navy-700 section section--above-the-fold section--content-left flex justify-start items-stretch bg--img-cover bg--img-free-shop-unloading"
-        style={{ backgroundImage: `url(${theFreeShopBackground})` }}
-      >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h1 className="section__title">
-              <img
-                width="130"
-                height="60"
-                src={logoSrc}
-                alt="Distribute Aid Logo: A flock of doves stylized by stacking wings behind the main outline of a dove."
-              />
-              <span>Delivery</span>
-            </h1>
-            <h2 className="text-2xl">Regular Route: UK&rarr;Lebanon</h2>
-          </header>
-
-          <div className="section__body">
-            <p className="mb-4">
-              Distribute Aid is organising a shipment of humanitarian aid
-              between the UK and Lebanon. We won't let pandemics or global
-              supply chain disruptions stop the flow of aid to those who need it
-              most! &#9829;
-            </p>
-            <p className="mb-4">
-              If you're here because you want to donate goods for displaced
-              peoples in Lebanon-{' '}
-              <strong className="text-uppercase">thank you!</strong> Groups on
-              the ground would not be able to provide the services they do
-              without support from donations like yours.
-            </p>
-
-            <div className="tiles tiles--grid tiles--highlight">
-              <div className="tile tile--column w-1/2">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={netIcon}
-                    alt="Hub Icon: Multiple nodes connected to a center hub."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">1 UK Staging Hub</p>
-                  <p>Cambridge</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/2">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={mapIcon}
-                    alt="Map Icon: A destination marker on a map."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Service to Lebanon</p>
-                  <p>Supporting 7 Frontline Groups</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/2">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={truckIcon}
-                    alt="Ship Icon: A container ship in motion."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Regular Shipments</p>
-                  <p>Scaled To Demand</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column w-1/2">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={heartBillIcon}
-                    alt="Money Icon: A currency bill with a heart in the middle."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Fair Flat-Rate Pricing</p>
-                  <p>All-Inclusive, At-Cost</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <footer>
-            <p className="photo-credit text-center hide-sm">
-              <span>Background Photo Credit:</span>{' '}
-              <a
-                href="https://www.instagram.com/thefreeshoplebanon/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Alice Corrigan of The Free Shop
-              </a>
-            </p>
-          </footer>
-        </div>
-      </section>
-
-      <section
-        id="reserve-your-spot"
-        className="section section--content-right bg--img-cover bg--img-pallet-storage"
-        style={{ backgroundImage: `url(${palletStorageBackground})` }}
-      >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h2 className="section__title">Reserve Your Spot!</h2>
-          </header>
-
-          <div className="section__body">
-            <ol className="">
-              <li className="">
-                <h4 className="text-lg font-semibold mb-4">
-                  1) Submit Your Aid Delivery Request
-                </h4>
-                <p className="mb-4">
-                  Download the{' '}
-                  <a
-                    className="stage-action"
-                    href="/docs/da_aid-delivery-request_uk-to-lebanon.xlsx"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Aid Delivery Request Form
-                  </a>{' '}
-                  and fill it in.
-                </p>
-                <p className="mb-4">
-                  Email the completed form to{' '}
-                  <a
-                    className="stage-action"
-                    href="mailto:hubs@distributeaid.org"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    hubs@distributeaid.org
-                  </a>
-                  . Your local Staging Hub will receive it and follow up if
-                  there are any questions.
-                </p>
-                <p className="h5">
-                  Submissions Close: Sunday, 21st November 2021
-                </p>
-              </li>
-              <li className="stage">
-                <h4 className="text-lg font-semibold mb-4">
-                  2) Consult Frontline Groups
-                </h4>
-                <p className="mb-4">
-                  We'll check in with the frontline groups after the form
-                  submission deadline, to prioritise deliveries that meet their
-                  biggest needs and build a manifest for the upcoming shipment
-                  with their input. Then we can confirm if you have a place
-                  reserved on the next container.
-                </p>
-                <p className="h5">
-                  Confirmation Date: Wednesday, 24th November 2021
-                </p>
-              </li>
-              <li className="stage">
-                <h4 className="text-lg font-semibold mb-4">
-                  3) Drop Off @ Staging Hubs
-                </h4>
-                <p className="mb-4">
-                  Schedule a drop-off appointment with your local Staging Hub,
-                  pay them the flat-rate{' '}
-                  <a href="#storage-and-shipping-charge">
-                    Storage &amp; Shipping charge
-                  </a>
-                  , and deliver the boxes of aid at the agreed time.
-                </p>
-                <p className="h5">
-                  Staging Period: 27th November - 2nd December 2021
-                </p>
-              </li>
-              <li className="stage">
-                <h4 className="text-lg font-semibold mb-4">
-                  4) Deliver The Aid
-                </h4>
-                <p className="mb-4">
-                  <strong>And that's it!</strong> Take an evening off to
-                  celebrate a job well done, we got it from here. Once your aid
-                  is delivered we'll follow up with an after-shipment report,
-                  including photos and acknowledgments from the frontline
-                  groups.
-                </p>
-                <p className="h5">
-                  Container Departs: Friday, 3rd November 2021
-                </p>
-              </li>
-            </ol>
-          </div>
-
-          <footer>
-            <p className="photo-credit text-center hide-sm">
-              <span>Background Photo Credit:</span>{' '}
-              <a href="https://unsplash.com/@ruchindra?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">
-                Ruchindra Gunasekara
-              </a>{' '}
-              <span>
-                on{' '}
-                <a href="https://unsplash.com/s/photos/warehouse?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">
-                  Unsplash
-                </a>
-              </span>
-            </p>
-          </footer>
-        </div>
-      </section>
-
-      <section
-        id="frontline-groups"
-        className="section section--content-left flex justify-start items-stretch bg--img-cover bg--img-its-lebanon"
-        style={{ backgroundImage: `url(${settlementLebanonBackground})` }}
-      >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h2 className="section__title">Frontline Groups</h2>
-          </header>
-
-          <div className="section__body">
-            <div className="tiles tiles--grid ">
-              <div className="tile tile--column col-3">
-                <div className="tile-icon tile-icon--auto">
-                  <StaticImage
-                    height={140}
-                    width={140}
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/the-free-shop-logo.392.png"
-                    alt="Frontline Group Logo: The Free Shop"
-                  />
-                </div>
-              </div>
-
-              <div className="tile tile--column col-7">
-                <div className="tile-icon tile-icon--auto">
-                  <StaticImage
-                    height={85}
-                    width={360}
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/beirut-celebrations-logo.1061x256.png"
-                    alt="Frontline Group Logo: Beirut Celebrations"
-                  />
-                </div>
-              </div>
-
-              <div className="tile tile--column col-7">
-                <div className="tile-icon tile-icon--auto">
-                  <StaticImage
-                    height={180}
-                    width={360}
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/ema-logo.512x256.jpg"
-                    alt="Frontline Group Logo: Endless Medical Advantage (EMA)"
-                  />
-                </div>
-              </div>
-
-              <div className="tile tile--column col-3">
-                <div className="tile-icon tile-icon--auto">
-                  <StaticImage
-                    height={145}
-                    width={145}
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/live-love-beirut-logo.256.png"
-                    alt="Frontline Group Logo: Live Love Beirut"
-                  />
-                </div>
-              </div>
-
-              <div className="tile tile--column col-6 col-mx-auto">
-                <div className="tile-icon tile-icon--auto">
-                  <StaticImage
-                    height={168}
-                    width={300}
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/wing-woman-logo.300x168.jpg"
-                    alt="Frontline Group Logo: Wing Woman"
-                  />
-                </div>
-              </div>
-
-              <div className="tile tile--column col-6 col-mx-auto">
-                <div className="tile-icon tile-icon--auto">
-                  <StaticImage
-                    height={173}
-                    width={307}
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/arcenciel-logo.455x256.jpg"
-                    alt="Frontline Group Logo: Arcenciel"
-                  />
-                </div>
-              </div>
-
-              <div className="tile tile--column col-6 col-mx-auto">
-                <div className="tile-icon tile-icon--auto">
-                  <StaticImage
-                    height={82}
-                    width={262}
-                    className="icon icon--responsive"
-                    src="../../images/regular-routes/shaabe-logo.262x82.jpg"
-                    alt="Frontline Group Logo: Shaabe"
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Shaabe</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <footer>
-            <p className="photo-credit text-center hide-sm">
-              <span>Background Photo Credit:</span>{' '}
-              <a
-                href="https://www.instagram.com/thefreeshoplebanon/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Alice Corrigan of The Free Shop
-              </a>
-            </p>
-          </footer>
-        </div>
-      </section>
-
-      <div className="flex">
-        <div className="w-full md:w-1/2">
-          <iframe
-            src="https://www.google.com/maps/d/u/0/embed?mid=1ZRALkbEQoigOjaT5tFEgJtVFkXBOW6LM"
-            width="100%"
-            height="100%"
+      <TextWithVisual
+        positionOfVisual="right"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="Two people sitting in the back of a fully loaded truck"
+            image={theFreeShopBackground}
           />
-        </div>
+        }
+      >
+        <header className="mb-4 text-center">
+          <h1 className="section__title">
+            <img
+              width="130"
+              height="60"
+              src={logoSrc}
+              alt="Distribute Aid Logo: A flock of doves stylized by stacking wings behind the main outline of a dove."
+            />
+            <span>Delivery</span>
+          </h1>
+          <h2 className="text-2xl">Regular Route: UK&rarr;Lebanon</h2>
+        </header>
 
-        <section id="uk-staging-hubs" className="section w-full md:w-1/2">
-          <div className="section__content bg-white">
-            <header className="mb-4 text-center">
-              <h1 className="section__title">UK Staging Hubs</h1>
-            </header>
+        <div className="section__body">
+          <p className="mb-4">
+            Distribute Aid is organising a shipment of humanitarian aid between
+            the UK and Lebanon. We won't let pandemics or global supply chain
+            disruptions stop the flow of aid to those who need it most! &#9829;
+          </p>
+          <p className="mb-4">
+            If you're here because you want to donate goods for displaced
+            peoples in Lebanon-{' '}
+            <strong className="text-uppercase">thank you!</strong> Groups on the
+            ground would not be able to provide the services they do without
+            support from donations like yours.
+          </p>
 
-            <div className="section__body">
-              <p>
-                The most <strong>cost efficient and pandemic-proof</strong> way
-                to send aid from the UK to Lebanon is by shipping palletised aid
-                in containers.{' '}
-                <strong>That's where our UK Staging Hubs come in!</strong> They
-                have the necessary infrastructure and experience working with us
-                to ensure each shipment is fully optimized, which everybody
-                benefits from. Once it's in a Staging Hub, your aid will be
-                palletised, stored, and loaded by a forklift onto the next
-                container.
-              </p>
-
-              <div className="tiles tiles--column ">
-                <div className="tile flex">
-                  <div className="tile-icon flex-shrink-0">
-                    <StaticImage
-                      src="../../images/regular-routes/pallet-aid-logo.256.png"
-                      alt="Hub Logo: Pallet Aid (PA)"
-                      height={80}
-                      width={80}
-                    />
-                  </div>
-                  <div className="tile-content">
-                    <p className="mb-1">Cambridgeshire</p>
-                    <p>Both Community &amp; Commercial Aid</p>
-                    <p className="text-italic">
-                      pallets, loose boxes, bulk bags of tents &amp; sleeping
-                      bags, etc
-                    </p>
-                  </div>
-                </div>
+          <div className="tiles tiles--grid tiles--highlight">
+            <div className="tile tile--column w-1/2">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={netIcon}
+                  alt="Hub Icon: Multiple nodes connected to a center hub."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">1 UK Staging Hub</p>
+                <p>Cambridge</p>
               </div>
             </div>
 
-            <footer>
-              <p className="photo-credit text-center hide-sm">
-                Questions? Comments? Contact us all at{' '}
+            <div className="tile tile--column w-1/2">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={mapIcon}
+                  alt="Map Icon: A destination marker on a map."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Service to Lebanon</p>
+                <p>Supporting 7 Frontline Groups</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/2">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={truckIcon}
+                  alt="Ship Icon: A container ship in motion."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Regular Shipments</p>
+                <p>Scaled To Demand</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column w-1/2">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={heartBillIcon}
+                  alt="Money Icon: A currency bill with a heart in the middle."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Fair Flat-Rate Pricing</p>
+                <p>All-Inclusive, At-Cost</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer>
+          <p className="photo-credit text-center hide-sm">
+            <span>Background Photo Credit:</span>{' '}
+            <a
+              href="https://www.instagram.com/thefreeshoplebanon/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Alice Corrigan of The Free Shop
+            </a>
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="reserve-your-spot"
+        positionOfVisual="left"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="An aisle in a warehouse with shelves stacked high with pallets of boxes."
+            image={palletStorageBackground}
+          />
+        }
+      >
+        <header className="mb-4 text-center">
+          <h2 className="section__title">Reserve Your Spot!</h2>
+        </header>
+        <div className="section__body">
+          <ol className="">
+            <li className="">
+              <h4 className="text-lg font-semibold mb-4">
+                1) Submit Your Aid Delivery Request
+              </h4>
+              <p className="mb-4">
+                Download the{' '}
                 <a
-                  href="mailto:hubs@distributeaid.org"
+                  className="stage-action"
+                  href="/docs/da_aid-delivery-request_uk-to-lebanon.xlsx"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  hubs@distributeaid.org
-                </a>
-                .
+                  Aid Delivery Request Form
+                </a>{' '}
+                and fill it in.
               </p>
-            </footer>
-          </div>
-        </section>
-      </div>
-
-      <section
-        id="storage-and-shipping-charge"
-        className="section--content-left section flex justify-start items-stretch bg--img-cover bg--img-forklift-loading-2"
-        style={{ backgroundImage: `url(${forkliftLoadingBackground})` }}
-      >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h1 className="section__title">Storage &amp; Shipping (£)</h1>
-          </header>
-
-          <div className="section__body">
-            <p>
-              We offer a flat, per-pallet storage and shipment charge (S&amp;S)
-              to take the stress out of budgeting to move your aid. By using the
-              Staging Hubs we can keep shipping costs low and consistent, and
-              spread the cost evenly for all groups sending aid.
-            </p>
-
-            <div className="tiles tiles--row ">
-              <div className="tile tile--column">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={palletIcon}
-                    alt="Standard Pallet Icon: Four boxes stacked evenly on a pallet."
-                  />
-                </div>
-                <div className="tile-content text-left">
-                  <p className="mb-1">Standard Pallet - ££</p>
-                  <p>1.2m x 1.0m x 1.70m high</p>
-                  <p>700kg</p>
-                </div>
-              </div>
-
-              <div className="tile tile--column">
-                <div className="tile-icon mx-auto">
-                  <img
-                    className="icon icon--responsive"
-                    src={halfPalletIcon}
-                    alt="Half Pallet Icon: 3 boxes stacked in a pyramid on a pallet."
-                  />
-                </div>
-                <div className="tile-content text-left">
-                  <p className="mb-1">Half Pallet - £</p>
-                  <p>1.2m x 1.0m x 0.85m high</p>
-                  <p>350kg</p>
-                </div>
-              </div>
-            </div>
-
-            <h3 className="text-xl font-medium">
-              What if my aid doesn't fit exactly?
-            </h3>
-
-            <ul>
-              <li>
-                We encourage groups to work together to submit a combined offer
-                that makes up a Standard Pallet or Half Pallet worth of aid.
-              </li>
-              <li>
-                We reserve 2 pallets worth of space on each truck for overflow,
-                so if you have slightly more then a Standard Pallet's worth of
-                aid that's ok! Overflow pricing is £6 per banana box (500mm x
-                400mm x 250mm high, holds 15kg).
-              </li>
-              <li>
-                You'll still need to book a Standard Pallet space for
-                commercially purchased aid with smaller pallet dimensions.
-                Unfortunately, due to the way trucks are packed a smaller pallet
-                size doesn't actually allow us to fit more on there. You can
-                always contact{' '}
+              <p className="mb-4">
+                Email the completed form to{' '}
                 <a
                   className="stage-action"
                   href="mailto:hubs@distributeaid.org"
@@ -501,156 +173,488 @@ const UkToLebanon: FC = () => {
                   rel="noopener noreferrer"
                 >
                   hubs@distributeaid.org
-                </a>{' '}
-                to look into booking a full truck load at a custom rate.
-              </li>
-              <li>
-                We can book you multiple Standard Pallets worth of space to
-                accommodate bulky items. Please submit the exact dimensions of
-                the item on the offer form so we can assess how many Standard
-                Pallets it will require, and ensure that we book the right type
-                of truck to load it.
-              </li>
-            </ul>
-
-            <h3 className="text-xl font-medium mt-12 mb-4">
-              How are contribution prices set?
-            </h3>
-
-            <p>
-              Our goal is to provide the best possible flat rate for sending
-              groups! The current contribution prices are based on shipping
-              prices so far this year. As of November/December 2021, the
-              price/pallet is currently set at £250, covering shipping, storage
-              and anticipated taxes.
-            </p>
-          </div>
-
-          <footer>
-            <p className="photo-credit text-center hide-sm">
-              <span>Background Photo Credit:</span>{' '}
-              <a
-                href="https://www.facebook.com/groups/hertsforrefugees/permalink/3488608217903521/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Mark Lampert of Herts For Refugees
-              </a>
-            </p>
-          </footer>
+                </a>
+                . Your local Staging Hub will receive it and follow up if there
+                are any questions.
+              </p>
+              <p className="h5">
+                Submissions Close: Sunday, 21st November 2021
+              </p>
+            </li>
+            <li className="stage">
+              <h4 className="text-lg font-semibold mb-4">
+                2) Consult Frontline Groups
+              </h4>
+              <p className="mb-4">
+                We'll check in with the frontline groups after the form
+                submission deadline, to prioritise deliveries that meet their
+                biggest needs and build a manifest for the upcoming shipment
+                with their input. Then we can confirm if you have a place
+                reserved on the next container.
+              </p>
+              <p className="h5">
+                Confirmation Date: Wednesday, 24th November 2021
+              </p>
+            </li>
+            <li className="stage">
+              <h4 className="text-lg font-semibold mb-4">
+                3) Drop Off @ Staging Hubs
+              </h4>
+              <p className="mb-4">
+                Schedule a drop-off appointment with your local Staging Hub, pay
+                them the flat-rate{' '}
+                <a href="#storage-and-shipping-charge">
+                  Storage &amp; Shipping charge
+                </a>
+                , and deliver the boxes of aid at the agreed time.
+              </p>
+              <p className="h5">
+                Staging Period: 27th November - 2nd December 2021
+              </p>
+            </li>
+            <li className="stage">
+              <h4 className="text-lg font-semibold mb-4">4) Deliver The Aid</h4>
+              <p className="mb-4">
+                <strong>And that's it!</strong> Take an evening off to celebrate
+                a job well done, we got it from here. Once your aid is delivered
+                we'll follow up with an after-shipment report, including photos
+                and acknowledgments from the frontline groups.
+              </p>
+              <p className="h5">Container Departs: Friday, 3rd November 2021</p>
+            </li>
+          </ol>
         </div>
-      </section>
 
-      <section
-        id="all-about-pallets"
-        className="section section--content-right bg--img-cover bg--img-collection-and-sorting"
-        style={{ backgroundImage: `url(${collectionBackground})` }}
+        <footer>
+          <p className="photo-credit text-center hide-sm">
+            <span>Background Photo Credit:</span>{' '}
+            <a href="https://unsplash.com/@ruchindra?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">
+              Ruchindra Gunasekara
+            </a>{' '}
+            <span>
+              on{' '}
+              <a href="https://unsplash.com/s/photos/warehouse?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">
+                Unsplash
+              </a>
+            </span>
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="frontline-groups"
+        positionOfVisual="right"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="A refugee settlement."
+            image={settlementLebanonBackground}
+          />
+        }
       >
-        <div className="section__content bg-white">
-          <header className="mb-4 text-center">
-            <h1 className="section__title">All About Pallets</h1>
-          </header>
-
-          <div className="section__body">
-            <h3>How many Standard Pallet spaces do I need?</h3>
-
-            <div className="tiles tiles--column ">
-              <div className="tile flex">
-                <div className="tile-icon w-20 flex-shrink-0">
-                  <img
-                    className="icon icon--responsive"
-                    src={vanIcon}
-                    alt="Van Icon: The Calais classic."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Van Loads</p>
-                  <p>
-                    The Calais classic. Most Vans fit about{' '}
-                    <strong>3 Standard Pallets</strong> worth of aid in the
-                    back.
-                  </p>
-                </div>
+        <header className="mb-4 text-center">
+          <h2 className="section__title">Frontline Groups</h2>
+        </header>
+        <div className="section__body">
+          <div className="tiles tiles--grid ">
+            <div className="tile tile--column col-3">
+              <div className="tile-icon tile-icon--auto">
+                <StaticImage
+                  height={140}
+                  width={140}
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/the-free-shop-logo.392.png"
+                  alt="Frontline Group Logo: The Free Shop"
+                />
               </div>
-              <div className="tile flex">
-                <div className="tile-icon w-20 flex-shrink-0">
-                  <img
-                    className="icon icon--responsive"
-                    src={sackIcon}
-                    alt="Bulk Bag Icon: A large sack."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Bulk Bags</p>
-                  <p>
-                    Perfect for those larger, clumsier items like tents or
-                    sleeping bags that are too awkward to box up.
-                  </p>
-                  <ul className="">
-                    <li>
-                      Each Bulk Bag takes up one <strong>Half Pallet</strong>{' '}
-                      space.
-                    </li>
-                    <li>
-                      2 Bulk Bags count as a <strong>Standard Pallet</strong> if
-                      they can be stacked.
-                    </li>
-                    <li>
-                      A <strong>Standard Pallet</strong> can also be made by
-                      stacking a Bulk Bag on top of 18 Banana Boxes.
-                    </li>
-                  </ul>
-                </div>
+            </div>
+
+            <div className="tile tile--column col-7">
+              <div className="tile-icon tile-icon--auto">
+                <StaticImage
+                  height={85}
+                  width={360}
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/beirut-celebrations-logo.1061x256.png"
+                  alt="Frontline Group Logo: Beirut Celebrations"
+                />
               </div>
-              <div className="tile flex">
-                <div className="tile-icon w-20 flex-shrink-0">
-                  <img
-                    className="icon icon--responsive"
-                    src={boxIcon}
-                    alt="Confirmed Box Icon: The proverbial banana box."
-                  />
-                </div>
-                <div className="tile-content">
-                  <p className="mb-1">Banana Boxes</p>
-                  <p>
-                    Easy to acquire, small, and sturdy boxes. Each Banana Box
-                    should hold a specific item, such as mens small pants or
-                    women's medium winter sweaters. Any consistently sized box
-                    could be used to fill a Standard or Half pallet. Banana Box
-                    sizes can vary a bit, but a good rule of thumb is:
-                  </p>
-                  <ul className="">
-                    <li>
-                      <strong>Dimensions:</strong> 500mm x 400mm x 250mm high,
-                      holds 15kg
-                    </li>
-                    <li>
-                      18 Banana Boxes make up a <strong>Half Pallet</strong>
-                    </li>
-                    <li>
-                      36 Banana Boxes can fit on a{' '}
-                      <strong>Standard Pallet</strong>
-                    </li>
-                  </ul>
-                </div>
+            </div>
+
+            <div className="tile tile--column col-7">
+              <div className="tile-icon tile-icon--auto">
+                <StaticImage
+                  height={180}
+                  width={360}
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/ema-logo.512x256.jpg"
+                  alt="Frontline Group Logo: Endless Medical Advantage (EMA)"
+                />
+              </div>
+            </div>
+
+            <div className="tile tile--column col-3">
+              <div className="tile-icon tile-icon--auto">
+                <StaticImage
+                  height={145}
+                  width={145}
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/live-love-beirut-logo.256.png"
+                  alt="Frontline Group Logo: Live Love Beirut"
+                />
+              </div>
+            </div>
+
+            <div className="tile tile--column col-6 col-mx-auto">
+              <div className="tile-icon tile-icon--auto">
+                <StaticImage
+                  height={168}
+                  width={300}
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/wing-woman-logo.300x168.jpg"
+                  alt="Frontline Group Logo: Wing Woman"
+                />
+              </div>
+            </div>
+
+            <div className="tile tile--column col-6 col-mx-auto">
+              <div className="tile-icon tile-icon--auto">
+                <StaticImage
+                  height={173}
+                  width={307}
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/arcenciel-logo.455x256.jpg"
+                  alt="Frontline Group Logo: Arcenciel"
+                />
+              </div>
+            </div>
+
+            <div className="tile tile--column col-6 col-mx-auto">
+              <div className="tile-icon tile-icon--auto">
+                <StaticImage
+                  height={82}
+                  width={262}
+                  className="icon icon--responsive"
+                  src="../../images/regular-routes/shaabe-logo.262x82.jpg"
+                  alt="Frontline Group Logo: Shaabe"
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Shaabe</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer>
+          <p className="photo-credit text-center hide-sm">
+            <span>Background Photo Credit:</span>{' '}
+            <a
+              href="https://www.instagram.com/thefreeshoplebanon/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Alice Corrigan of The Free Shop
+            </a>
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="frontline-groups"
+        positionOfVisual="left"
+        visual={
+          <iframe
+            className="w-full md:w-2/4 h-96 md:h-auto"
+            src="https://www.google.com/maps/d/u/0/embed?mid=1ZRALkbEQoigOjaT5tFEgJtVFkXBOW6LM"
+            width="100%"
+            height="100%"
+          />
+        }
+      >
+        <header className="mb-4 text-center">
+          <h1 className="section__title">UK Staging Hubs</h1>
+        </header>
+
+        <div className="section__body">
+          <p>
+            The most <strong>cost efficient and pandemic-proof</strong> way to
+            send aid from the UK to Lebanon is by shipping palletised aid in
+            containers.{' '}
+            <strong>That's where our UK Staging Hubs come in!</strong> They have
+            the necessary infrastructure and experience working with us to
+            ensure each shipment is fully optimized, which everybody benefits
+            from. Once it's in a Staging Hub, your aid will be palletised,
+            stored, and loaded by a forklift onto the next container.
+          </p>
+
+          <div className="tiles tiles--column ">
+            <div className="tile flex">
+              <div className="tile-icon flex-shrink-0">
+                <StaticImage
+                  src="../../images/regular-routes/pallet-aid-logo.256.png"
+                  alt="Hub Logo: Pallet Aid (PA)"
+                  height={80}
+                  width={80}
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Cambridgeshire</p>
+                <p>Both Community &amp; Commercial Aid</p>
+                <p className="text-italic">
+                  pallets, loose boxes, bulk bags of tents &amp; sleeping bags,
+                  etc
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer>
+          <p className="photo-credit text-center hide-sm">
+            Questions? Comments? Contact us all at{' '}
+            <a
+              href="mailto:hubs@distributeaid.org"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              hubs@distributeaid.org
+            </a>
+            .
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="storage-and-shipping-charge"
+        positionOfVisual="right"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="Pallets with lots of cans of food and a person celebrating the successful unloading."
+            image={forkliftLoadingBackground}
+          />
+        }
+      >
+        <header className="mb-4 text-center">
+          <h1 className="section__title">Storage &amp; Shipping (£)</h1>
+        </header>
+
+        <div className="section__body">
+          <p>
+            We offer a flat, per-pallet storage and shipment charge (S&amp;S) to
+            take the stress out of budgeting to move your aid. By using the
+            Staging Hubs we can keep shipping costs low and consistent, and
+            spread the cost evenly for all groups sending aid.
+          </p>
+
+          <div className="tiles tiles--row ">
+            <div className="tile tile--column">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={palletIcon}
+                  alt="Standard Pallet Icon: Four boxes stacked evenly on a pallet."
+                />
+              </div>
+              <div className="tile-content text-left">
+                <p className="mb-1">Standard Pallet - ££</p>
+                <p>1.2m x 1.0m x 1.70m high</p>
+                <p>700kg</p>
+              </div>
+            </div>
+
+            <div className="tile tile--column">
+              <div className="tile-icon mx-auto">
+                <img
+                  className="icon icon--responsive"
+                  src={halfPalletIcon}
+                  alt="Half Pallet Icon: 3 boxes stacked in a pyramid on a pallet."
+                />
+              </div>
+              <div className="tile-content text-left">
+                <p className="mb-1">Half Pallet - £</p>
+                <p>1.2m x 1.0m x 0.85m high</p>
+                <p>350kg</p>
               </div>
             </div>
           </div>
 
-          <footer>
-            <p className="photo-credit text-center hide-sm">
-              <span>Background Photo Credit:</span>{' '}
+          <h3 className="text-xl font-medium">
+            What if my aid doesn't fit exactly?
+          </h3>
+
+          <ul>
+            <li>
+              We encourage groups to work together to submit a combined offer
+              that makes up a Standard Pallet or Half Pallet worth of aid.
+            </li>
+            <li>
+              We reserve 2 pallets worth of space on each truck for overflow, so
+              if you have slightly more then a Standard Pallet's worth of aid
+              that's ok! Overflow pricing is £6 per banana box (500mm x 400mm x
+              250mm high, holds 15kg).
+            </li>
+            <li>
+              You'll still need to book a Standard Pallet space for commercially
+              purchased aid with smaller pallet dimensions. Unfortunately, due
+              to the way trucks are packed a smaller pallet size doesn't
+              actually allow us to fit more on there. You can always contact{' '}
               <a
-                href="https://www.facebook.com/DGRefugeeAction"
+                className="stage-action"
+                href="mailto:hubs@distributeaid.org"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Jay Rubenstien of Massive Outpouring of Love
-              </a>
-            </p>
-          </footer>
+                hubs@distributeaid.org
+              </a>{' '}
+              to look into booking a full truck load at a custom rate.
+            </li>
+            <li>
+              We can book you multiple Standard Pallets worth of space to
+              accommodate bulky items. Please submit the exact dimensions of the
+              item on the offer form so we can assess how many Standard Pallets
+              it will require, and ensure that we book the right type of truck
+              to load it.
+            </li>
+          </ul>
+
+          <h3 className="text-xl font-medium mt-12 mb-4">
+            How are contribution prices set?
+          </h3>
+
+          <p>
+            Our goal is to provide the best possible flat rate for sending
+            groups! The current contribution prices are based on shipping prices
+            so far this year. As of November/December 2021, the price/pallet is
+            currently set at £250, covering shipping, storage and anticipated
+            taxes.
+          </p>
         </div>
-      </section>
+
+        <footer>
+          <p className="photo-credit text-center hide-sm">
+            <span>Background Photo Credit:</span>{' '}
+            <a
+              href="https://www.facebook.com/groups/hertsforrefugees/permalink/3488608217903521/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Mark Lampert of Herts For Refugees
+            </a>
+          </p>
+        </footer>
+      </TextWithVisual>
+
+      <TextWithVisual
+        id="all-about-pallets"
+        positionOfVisual="left"
+        visual={
+          <RoutesSectionImage
+            ariaLabel="Three people sorting and packing clothes into boxes."
+            image={collectionBackground}
+          />
+        }
+      >
+        <header className="mb-4 text-center">
+          <h1 className="section__title">All About Pallets</h1>
+        </header>
+        <div className="section__body">
+          <h3>How many Standard Pallet spaces do I need?</h3>
+
+          <div className="tiles tiles--column ">
+            <div className="tile flex">
+              <div className="tile-icon w-20 flex-shrink-0">
+                <img
+                  className="icon icon--responsive"
+                  src={vanIcon}
+                  alt="Van Icon: The Calais classic."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Van Loads</p>
+                <p>
+                  The Calais classic. Most Vans fit about{' '}
+                  <strong>3 Standard Pallets</strong> worth of aid in the back.
+                </p>
+              </div>
+            </div>
+            <div className="tile flex">
+              <div className="tile-icon w-20 flex-shrink-0">
+                <img
+                  className="icon icon--responsive"
+                  src={sackIcon}
+                  alt="Bulk Bag Icon: A large sack."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Bulk Bags</p>
+                <p>
+                  Perfect for those larger, clumsier items like tents or
+                  sleeping bags that are too awkward to box up.
+                </p>
+                <ul className="">
+                  <li>
+                    Each Bulk Bag takes up one <strong>Half Pallet</strong>{' '}
+                    space.
+                  </li>
+                  <li>
+                    2 Bulk Bags count as a <strong>Standard Pallet</strong> if
+                    they can be stacked.
+                  </li>
+                  <li>
+                    A <strong>Standard Pallet</strong> can also be made by
+                    stacking a Bulk Bag on top of 18 Banana Boxes.
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <div className="tile flex">
+              <div className="tile-icon w-20 flex-shrink-0">
+                <img
+                  className="icon icon--responsive"
+                  src={boxIcon}
+                  alt="Confirmed Box Icon: The proverbial banana box."
+                />
+              </div>
+              <div className="tile-content">
+                <p className="mb-1">Banana Boxes</p>
+                <p>
+                  Easy to acquire, small, and sturdy boxes. Each Banana Box
+                  should hold a specific item, such as mens small pants or
+                  women's medium winter sweaters. Any consistently sized box
+                  could be used to fill a Standard or Half pallet. Banana Box
+                  sizes can vary a bit, but a good rule of thumb is:
+                </p>
+                <ul className="">
+                  <li>
+                    <strong>Dimensions:</strong> 500mm x 400mm x 250mm high,
+                    holds 15kg
+                  </li>
+                  <li>
+                    18 Banana Boxes make up a <strong>Half Pallet</strong>
+                  </li>
+                  <li>
+                    36 Banana Boxes can fit on a{' '}
+                    <strong>Standard Pallet</strong>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer>
+          <p className="photo-credit text-center hide-sm">
+            <span>Background Photo Credit:</span>{' '}
+            <a
+              href="https://www.facebook.com/DGRefugeeAction"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Jay Rubenstien of Massive Outpouring of Love
+            </a>
+          </p>
+        </footer>
+      </TextWithVisual>
     </SimpleLayout>
   )
 }

--- a/src/stylesheets/routes.css
+++ b/src/stylesheets/routes.css
@@ -4,27 +4,6 @@ Legacy CSS for the routes pages
 /routes/uk-to-france
 */
 
-.section--content-left,
-.section--content-right {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: stretch;
-}
-
-.section--content-left .section__content {
-  width: 50%;
-}
-
-.section--content-right .section__content {
-  width: 50%;
-  margin-left: auto;
-}
-
-.section__content {
-  padding: 1rem;
-}
-
 .section__title {
   display: flex;
   justify-content: center;
@@ -32,13 +11,6 @@ Legacy CSS for the routes pages
   margin-bottom: 0;
   font-size: 2.4rem;
   text-transform: uppercase;
-}
-
-@media only screen and (max-device-width: 600px) {
-  .section--content-left .section__content,
-  .section--content-right .section__content {
-    width: 100%;
-  }
 }
 
 .section--above-the-fold {
@@ -218,42 +190,4 @@ Accessibility
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   border: 0;
-}
-
-/*
-Background & Color
-------------------------------------------------------------
-*/
-.bg--img-cover {
-  background: no-repeat center center fixed;
-  background-size: cover;
-  background-color: #c5cfe4; /* fallback if no image is used */
-}
-
-.bg--img-forklift-loading,
-.bg--img-its-lebanon {
-  background: no-repeat center right;
-  background-size: contain;
-}
-
-.bg--img-forklift-loading-2,
-.bg--img-cfc-unloading {
-  background: no-repeat center right;
-  background-size: cover;
-}
-
-.bg--img-pallet-storage {
-  background: no-repeat center left;
-  background-size: contain;
-}
-
-.bg--img-collection-and-sorting {
-  background: no-repeat center left;
-  background-size: 50% auto;
-}
-
-.bg--img-free-shop-unloading,
-.bg--img-mrs-distro {
-  background: no-repeat center right;
-  background-size: 50% auto;
 }


### PR DESCRIPTION
This addresses https://github.com/distributeaid/distributeaid.org/issues/136

I created a new component for each section on the routes pages. The component consists of a visual and a text section. On larger screen sizes, the text and visual are next to each other and on smaller screen sizes, the visual is underneath the corresponding text.

I didn't make any changes in the existing HTML text sections, I only replaced the wrapping elements with the new component.

Moving forward, it might be worth extracting more React components from those routes pages but as it's not really related to fixing the mobile responsiveness issue, I haven't looked at it in detail yet.

Please let me know any feedback! 

One thing that is potentially a concern is that the images aren't always positioned correctly because the background resizes depending on the corresponding text section. So sometimes the most important content of the image isn't visible. But I think that's a content issue rather than a code issue... I saw that there was some custom background positioning depending on which image was used - but I don't think that's feasible when switching to a CMS now. I think the content editor probably needs to crop or choose the image accordingly. Would be interested to hear if you agree or if you think that we should somehow better accommodate different image dimensions and positioning . 

Screenshots of some sections as examples:

![image](https://user-images.githubusercontent.com/8995723/150798424-5f14b5ee-c897-4e5a-a9df-1fae01e03a85.png)
![image](https://user-images.githubusercontent.com/8995723/150798541-c858a3c3-a208-4a9c-a52f-5fd980a2a506.png)





