### PR TITLE
Hide image carousel tile on smaller screens

### DIFF
--- a/src/components/home/CarouselTile.tsx
+++ b/src/components/home/CarouselTile.tsx
@@ -23,7 +23,7 @@ const CarouselTile: FC<Props> = ({
 
   return (
     <div
-      className="relative overflow-hidden"
+      className="relative overflow-hidden hidden md:block"
       style={{ width: size, height: size }}
     >
       {images.map((image, index) => (


### PR DESCRIPTION
Hi friends 👋 
I had a look at this issue https://github.com/distributeaid/distributeaid.org/issues/135

This solution simply hides the whole image carousel on smaller screens. 
@ramonh suggested to still display one carousel tile below the title but I followed this suggestion in the code for now 😅 
https://github.com/distributeaid/distributeaid.org/blob/44f90c6534a3c10449f5761deb5989e3b12cbec5/src/components/home/ImageCarousel.tsx#L47

Happy to look at how to display that one image in a separate PR if we want that.
But I thought this simple solution at least makes it a little better on smaller screens! And I guess you'll get to the main information quicker without having to scroll past the image on mobile 🤷 

**Mobile:**

<img width="357" alt="Screenshot 2022-02-25 at 15 49 42" src="https://user-images.githubusercontent.com/8995723/155677210-356b3d5d-01ad-436c-8c05-243132448cef.png">


**Desktop:**

<img width="1130" alt="Screenshot 2022-02-25 at 15 50 05" src="https://user-images.githubusercontent.com/8995723/155677224-3e98dd31-eea8-4706-9fe0-76f059fba181.png">


