### PR TITLE
Load team data models and expose them via the Gatsby API

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,7 +42,7 @@ module.exports = {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `markdown-pages`,
-        path: `${__dirname}/content/pages`,
+        path: `${__dirname}/content/`,
       },
     },
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -37,6 +37,17 @@ Customize the GraqphQL Schema
 */
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
+
+  const typeDefs = `
+    type DATeamTenure implements Node {
+      role: DATeamRole
+      start: Date
+      end: Date
+      isActive: Boolean
+    }
+  `
+
+  createTypes(typeDefs)
 }
 
 /*

--- a/gatsby/create-resolvers.js
+++ b/gatsby/create-resolvers.js
@@ -1,5 +1,9 @@
 module.exports = createResolvers = ({ createResolvers, getNode }) => {
   const resolvers = {
+    /*
+    Region
+    ------------------------------------------------------------
+    */
     DARegion: {
       subregions: {
         type: ['DASubregion'],
@@ -19,6 +23,10 @@ module.exports = createResolvers = ({ createResolvers, getNode }) => {
       map: imageSharpResolver(getNode, 'mapFileRelativePath'),
     },
 
+    /*
+    Subregion
+    ------------------------------------------------------------
+    */
     DASubregion: {
       region: {
         type: 'DARegion',
@@ -38,6 +46,17 @@ module.exports = createResolvers = ({ createResolvers, getNode }) => {
       map: imageSharpResolver(getNode, 'mapFileRelativePath'),
     },
 
+    /*
+    Team Member
+    ------------------------------------------------------------
+    TODO: Consider creating the DATeamTenure nodes in transform-nodes and
+          using Gatsby's @link directive in createSchemaCustomization to
+          automatically link them to the DATeamMember.
+
+          This technique may be applicable to all our resolvers.
+
+          https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#foreign-key-fields
+    */
     DATeamMember: {
       roles: {
         type: ['DATeamTenure'],
@@ -80,6 +99,10 @@ module.exports = createResolvers = ({ createResolvers, getNode }) => {
   createResolvers(resolvers)
 }
 
+/*
+Helpers
+================================================================================
+*/
 const imageSharpResolver = (getNode, pathKey) => {
   return {
     type: 'ImageSharp',

--- a/gatsby/transform-nodes.js
+++ b/gatsby/transform-nodes.js
@@ -16,13 +16,13 @@ module.exports = onCreateNode = ({
     minimatch(node.fileAbsolutePath, '**/content/**/*.md')
   ) {
     const fm = node.frontmatter
+
     // Regions
     if (
       minimatch(node.fileAbsolutePath, '**/content/pages/regions/*/index.md')
     ) {
       const fileRelativePath = path.join(
         'content',
-        'pages',
         getNode(node.parent).relativePath,
       )
 
@@ -56,7 +56,6 @@ module.exports = onCreateNode = ({
     ) {
       const fileRelativePath = path.join(
         'content',
-        'pages',
         getNode(node.parent).relativePath,
       )
 
@@ -77,6 +76,79 @@ module.exports = onCreateNode = ({
         children: [],
         internal: {
           type: 'DASubregion',
+          contentDigest: createContentDigest(fm),
+        },
+      })
+    }
+
+    // Team Roles
+    else if (minimatch(node.fileAbsolutePath, '**/content/blocks/roles/*.md')) {
+      const fileRelativePath = path.join(
+        'content',
+        getNode(node.parent).relativePath,
+      )
+
+      createNode({
+        // Node Data
+        title: fm.title,
+        desc: fm.desc,
+        location: fm.location,
+        domain: fm.domain,
+        commitment: fm.commitment,
+
+        // Metadata
+        fileRelativePath: fileRelativePath,
+
+        // Gatsby Fields
+        id: createNodeId(
+          `DA Team Role - ${fm.title} ${fm.location}  ${fm.commitment}`,
+        ),
+        parent: node.id,
+        children: [],
+        internal: {
+          type: 'DATeamRole',
+          contentDigest: createContentDigest(fm),
+        },
+      })
+    }
+
+    // Team Members
+    else if (
+      minimatch(node.fileAbsolutePath, '**/content/blocks/members/*.md')
+    ) {
+      const fileRelativePath = path.join(
+        'content',
+        getNode(node.parent).relativePath,
+      )
+
+      const roleData = fm.roles.map((role) => {
+        return {
+          fileRelativePath: role.role,
+          start: role.start,
+          end: role.end,
+          isActive: role.end === null,
+          role: null,
+        }
+      })
+
+      createNode({
+        // Node Data
+        name: fm.name,
+        bio: fm.bio,
+        link: fm.link,
+        beyondDA: fm.beyondDA,
+
+        // Metadata
+        fileRelativePath: fileRelativePath,
+        profilePhotoFileRelativePath: fm.profilePhoto,
+        roleData: roleData,
+
+        // Gatsby Fields
+        id: createNodeId(`DA Team Member - ${fm.name}`),
+        parent: node.id,
+        children: [],
+        internal: {
+          type: 'DATeamMember',
           contentDigest: createContentDigest(fm),
         },
       })

--- a/gatsby/transform-nodes.js
+++ b/gatsby/transform-nodes.js
@@ -9,7 +9,11 @@ module.exports = onCreateNode = ({
   getNode,
 }) => {
   const { createNode, createNodeField } = actions
-  // Forestry Files
+
+  /*
+  Forestry Data
+  ================================================================================
+  */
   if (
     node.internal.type === 'MarkdownRemark' &&
     node.fileAbsolutePath &&
@@ -17,7 +21,10 @@ module.exports = onCreateNode = ({
   ) {
     const fm = node.frontmatter
 
-    // Regions
+    /*
+    Regions
+    ------------------------------------------------------------
+    */
     if (
       minimatch(node.fileAbsolutePath, '**/content/pages/regions/*/index.md')
     ) {
@@ -48,10 +55,12 @@ module.exports = onCreateNode = ({
           contentDigest: createContentDigest(fm),
         },
       })
-    }
+    } else if (
 
-    // Subregions
-    else if (
+    /*
+    Subregions
+    ------------------------------------------------------------
+    */
       minimatch(node.fileAbsolutePath, '**/content/pages/regions/*/!(index).md')
     ) {
       const fileRelativePath = path.join(
@@ -79,10 +88,14 @@ module.exports = onCreateNode = ({
           contentDigest: createContentDigest(fm),
         },
       })
-    }
+    } else if (
 
-    // Team Roles
-    else if (minimatch(node.fileAbsolutePath, '**/content/blocks/roles/*.md')) {
+    /*
+    Team Roles
+    ------------------------------------------------------------
+    */
+      minimatch(node.fileAbsolutePath, '**/content/blocks/roles/*.md')
+    ) {
       const fileRelativePath = path.join(
         'content',
         getNode(node.parent).relativePath,
@@ -110,10 +123,12 @@ module.exports = onCreateNode = ({
           contentDigest: createContentDigest(fm),
         },
       })
-    }
+    } else if (
 
-    // Team Members
-    else if (
+    /*
+    Team Members
+    ------------------------------------------------------------
+    */
       minimatch(node.fileAbsolutePath, '**/content/blocks/members/*.md')
     ) {
       const fileRelativePath = path.join(
@@ -155,6 +170,16 @@ module.exports = onCreateNode = ({
     } else {
       // do nothing for other markdown remark types
     }
+
+    /*
+  Json Data
+  ================================================================================
+  */
+
+    /*
+  Line Items
+  ------------------------------------------------------------
+  */
   } else if (node.internal.type === 'CombinedManifestsJson') {
     const rawValue = node['$ Total']
     const value = parseFloat(rawValue?.replaceAll(/[\$,]/g, ''))


### PR DESCRIPTION
Resolves #508. Gatsby API now exposes:

  - DATeamMember
  - DATeamTenure (links team members to team roles w/ some added metadata)
  - DATeamRole