### PR TITLE
Fix for issue #563

### DIFF
--- a/src/components/vis/shipments-on-globe.tsx
+++ b/src/components/vis/shipments-on-globe.tsx
@@ -106,8 +106,8 @@ const ShipmentsOnGlobeVis: FC<Props> = ({ categoryVisItems }) => {
         arcDashGap={0.2}
         arcDashAnimateTime={() => Math.random() * 4000 + 500}
         arcStroke={1.1}
-        width={384}
-        height={384}
+        width={350}
+        height={350}
       />
     </div>
   )


### PR DESCRIPTION
Fixes issue [#563](https://github.com/distributeaid/distributeaid.org/issues/563#issue-1356882593). Globe in component is much too wide for mobile screens. Resolved by resizing the width and height values to 350px. 