### PR TITLE
fix: svg import type definition

### DIFF
--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -1,0 +1,10 @@
+declare module '*.svg' {
+  import * as React from 'react'
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement> & { title?: string }
+  >
+
+  const src: string
+  export default src
+}


### PR DESCRIPTION
This PR introduces a type declaration for the `.svg` files, so typescript knows what to expect from svg files, reducing the number of type errors from `51` to `27`.

This is part of the solution for the issue #756