### PR TITLE
Add e2e tests for routes pages

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,3 +29,4 @@ By contributing to this project you agree to:
 - Rabea Gleissner
 - Aksa
 - Lindsay Rainey
+- Tymur Levtsun

--- a/e2e-tests/donate.spec.ts
+++ b/e2e-tests/donate.spec.ts
@@ -14,7 +14,7 @@ test.describe('Donate action', () => {
     }) => {
       await page.goto(base)
       await page.locator('header >> a:has-text("Donate"):visible').click()
-      await expect(page).toHaveURL(new URL('/donate', base).toString())
+      await expect(page).toHaveURL(new URL('/donate/', base).toString())
       expect(
         await page.locator('data-test=opencollective').textContent(),
       ).toContain('Open Collective')
@@ -26,7 +26,7 @@ test.describe('Donate action', () => {
 
   test.describe('Donate page', () => {
     it('should show Open Collective info', async ({ page }) => {
-      await page.goto(new URL('/donate', base).toString())
+      await page.goto(new URL('/donate/', base).toString())
       expect(
         await page.locator('data-test=opencollective').textContent(),
       ).toContain('Open Collective')
@@ -37,7 +37,7 @@ test.describe('Donate action', () => {
     })
 
     it('should show Bank info', async ({ page }) => {
-      await page.goto(new URL('/donate', base).toString())
+      await page.goto(new URL('/donate/', base).toString())
       expect(await page.locator('data-test=bank').textContent()).toContain(
         'View bank info',
       )

--- a/e2e-tests/routes.spec.ts
+++ b/e2e-tests/routes.spec.ts
@@ -1,0 +1,52 @@
+import { expect, Page, test } from '@playwright/test'
+import { checkForConsoleErrors } from './lib/checkForConsoleErrors'
+import { baseUrl } from './lib/testHost'
+const it = test
+
+test.afterEach(checkForConsoleErrors)
+
+const base = baseUrl()
+const routePageSections = [
+  'DELIVERY',
+  'RESERVE YOUR SPOT!',
+  'FRONTLINE GROUPS',
+  'UK STAGING HUBS',
+  'STORAGE & SHIPPING (£)',
+  'ALL ABOUT PALLETS',
+]
+
+async function getAllSectionHeaders(page: Page) {
+  return Promise.all(
+    (await page.$$('header >> h1')).map(async (item) => {
+      return item.innerText()
+    }),
+  )
+}
+
+test.describe('Uk to Lebanon Route', () => {
+  const lebanonRouteUrl = new URL('/routes/uk-to-lebanon', base).toString()
+
+  it('Should have the correct title', async ({ page }) => {
+    await page.goto(lebanonRouteUrl)
+    await expect(page).toHaveTitle('Route: UK to Lebanon · Distribute Aid')
+  })
+  it('Should have the proper sections', async ({ page }) => {
+    await page.goto(lebanonRouteUrl)
+    const sectionsHeaders = await getAllSectionHeaders(page)
+    await expect(sectionsHeaders).toEqual(routePageSections)
+  })
+})
+
+test.describe('Uk to France Route', () => {
+  const franceRouteUrl = new URL('/routes/uk-to-france', base).toString()
+
+  it('Should have the correct title', async ({ page }) => {
+    await page.goto(franceRouteUrl)
+    await expect(page).toHaveTitle('Route: UK to France · Distribute Aid')
+  })
+  it('Should have the proper sections', async ({ page }) => {
+    await page.goto(franceRouteUrl)
+    const sectionsHeaders = await getAllSectionHeaders(page)
+    await expect(sectionsHeaders).toEqual(routePageSections)
+  })
+})

--- a/src/components/nav/MainMenu/MainMenu.tsx
+++ b/src/components/nav/MainMenu/MainMenu.tsx
@@ -16,8 +16,8 @@ const linksHardcoded: NavLinkItem[] = [
 ]
 
 const routeLinks: NavLinkItem[] = [
-  { label: 'UK to France', path: '/routes/uk-to-france' },
-  { label: 'UK to Lebanon', path: '/routes/uk-to-lebanon' },
+  { label: 'UK to France', path: '/routes/uk-to-france/' },
+  { label: 'UK to Lebanon', path: '/routes/uk-to-lebanon/' },
 ]
 
 /**

--- a/src/components/nav/MainMenu/MainMenuDesktop.tsx
+++ b/src/components/nav/MainMenu/MainMenuDesktop.tsx
@@ -45,7 +45,7 @@ const DesktopNavigation: FunctionComponent<Props> = ({
           </nav>
         )}
         <Link
-          to="/donate"
+          to="/donate/"
           className="py-2 px-6 rounded bg-white transition-colors text-navy-700"
         >
           Donate

--- a/src/components/nav/MainMenu/MainMenuMobile.tsx
+++ b/src/components/nav/MainMenu/MainMenuMobile.tsx
@@ -80,7 +80,7 @@ const MobileNavigation: FunctionComponent<Props> = ({
 
         <li>
           <Link
-            to="/donate"
+            to="/donate/"
             className="mt-8 block mx-4 py-2 px-6 text-center rounded bg-white transition-colors text-navy-700"
           >
             Donate


### PR DESCRIPTION
Implement two e2e tests for both France and Lebanon routes.
These tests are: 
- Check if the page has a correct title
- Check if page include all proper headers for sections