### PR TITLE
fix: Fundraiser page title is undefined

### DIFF
--- a/src/pages/donate/{DAFundraiser.name}.tsx
+++ b/src/pages/donate/{DAFundraiser.name}.tsx
@@ -31,7 +31,11 @@ type Props = {
   }
 }
 
-export function Head({ pageContext: fundraiser }: { pageContext: Fundraiser }) {
+export function Head({
+  data: { fundraiser: fundraiser },
+}: {
+  data: { fundraiser: Fundraiser }
+}) {
   return (
     <PageHeader
       title={`Donate to ${fundraiser.title}`}


### PR DESCRIPTION
closes issue 866

The `pageContext` doesn't supply the `title` property. I switched over to using the provided `data` object, which in this case supplies the `fundraiser` object which has the `title` property. :sunglasses: